### PR TITLE
answer와 Improvement 저장로직 수행시 admin이 null인 버그 해결

### DIFF
--- a/src/main/java/com/moment/the/config/security/auth/MyUserDetailsService.java
+++ b/src/main/java/com/moment/the/config/security/auth/MyUserDetailsService.java
@@ -1,11 +1,9 @@
 package com.moment.the.config.security.auth;
 
-import com.moment.the.admin.AdminDomain;
 import com.moment.the.admin.repository.AdminRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -14,8 +12,7 @@ public class MyUserDetailsService implements UserDetailsService {
     private final AdminRepository adminRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        AdminDomain adminDomain = adminRepository.findByAdminId(email);
-        return adminDomain;
+    public UserDetails loadUserByUsername(String email) {
+        return adminRepository.findByAdminId(email);
     }
 }

--- a/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
@@ -55,10 +55,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
      */
     private String accessTokenExtractEmail(String accessToken) {
         try {
-            if(jwtUtil.getTokenType(accessToken).equals(JwtUtil.TokenType.ACCESS_TOKEN.value))
-                return jwtUtil.getUserEmail(accessToken);
-            else
-                return null;
+            return jwtUtil.getUserEmail(accessToken);
         } catch (JwtException | IllegalArgumentException e ) {
             throw new InvalidTokenException();
         }

--- a/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
+++ b/src/main/java/com/moment/the/config/security/jwt/JwtRequestFilter.java
@@ -3,10 +3,7 @@ package com.moment.the.config.security.jwt;
 import com.moment.the.config.security.auth.MyUserDetailsService;
 import com.moment.the.exceptionAdvice.exception.InvalidTokenException;
 import com.moment.the.exceptionAdvice.exception.UserNotFoundException;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
-import io.jsonwebtoken.security.SignatureException;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -34,24 +31,15 @@ public class JwtRequestFilter extends OncePerRequestFilter {
         String accessToken = req.getHeader("Authorization");
         String refreshToken = req.getHeader("RefreshToken");
 
-        String userEmail;
-
         // Access Token이 null이면 검증할 필요가 없다.
         if (accessToken != null) {
-            log.debug("=== accessToken 검증 시작 ===");
+            String userEmail = accessTokenExtractEmail(accessToken);
 
-            userEmail = accessTokenExtractEmail(accessToken);
-            if(userEmail != null)
-                registerUserInfoInSecurityContext(userEmail, req);
-
+            if(userEmail != null) registerUserinfoInSecurityContext(userEmail, req);
             // Access Token이 만료되고 Refresh Token이 존재해야지 새로운 AccessToken을 반한한다.
             if(jwtUtil.isTokenExpired(accessToken) && refreshToken != null){
-                log.debug("=== AccessToken 만료 ===");
-
                 String newAccessToken = generateNewAccessToken(refreshToken);
                 res.addHeader("JwtToken", newAccessToken);
-
-                log.debug("=== AccessToken 발급 ===");
             }
         }
         filterChain.doFilter(req, res);
@@ -67,13 +55,11 @@ public class JwtRequestFilter extends OncePerRequestFilter {
      */
     private String accessTokenExtractEmail(String accessToken) {
         try {
-            if(jwtUtil.getTokenType(accessToken).equals(JwtUtil.TokenType.REFRESH_TOKEN.value))
-                return accessToken;
+            if(jwtUtil.getTokenType(accessToken).equals(JwtUtil.TokenType.ACCESS_TOKEN.value))
+                return jwtUtil.getUserEmail(accessToken);
             else
                 return null;
-        } catch (IllegalArgumentException | ExpiredJwtException e) {
-            return null;
-        } catch (MalformedJwtException | UnsupportedJwtException | SignatureException e ) {
+        } catch (JwtException | IllegalArgumentException e ) {
             throw new InvalidTokenException();
         }
     }
@@ -86,7 +72,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
      * @throws UserNotFoundException - 해당 사용자가 없을 경우 throw 된다.
      * @author 정시원
      */
-    private void registerUserInfoInSecurityContext(String userEmail, HttpServletRequest req) {
+    private void registerUserinfoInSecurityContext(String userEmail, HttpServletRequest req) {
         try {
             UserDetails userDetails = myUserDetailsService.loadUserByUsername(userEmail);
 
@@ -107,7 +93,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
     private String generateNewAccessToken(String refreshToken) {
         try {
             return jwtUtil.generateAccessToken(jwtUtil.getUserEmail(refreshToken));
-        } catch (IllegalArgumentException | UnsupportedJwtException | SignatureException | MalformedJwtException | ExpiredJwtException e) {
+        } catch (JwtException | IllegalArgumentException e) {
             throw new InvalidTokenException();
         }
     }


### PR DESCRIPTION
### 문제원인 및 해결
**`JwtRequestFilter`에서 `AccessToken`을 검증후 `userEmail`를 추출 하지못해 유저정보를 `SecurityContext`에 등록하지 못했습니다.**

그로인해 현재 로그인한 유저의 email를 반환하는 `AdminServiceImpl`의 `getUserEmail`메서드는 항상 null를 반환하여 `answer`와`Improvement` 저장 로직에서 `admin`을 정상적으로 등록하지 못했습니다.

#### 해결 방안
`JwtRequestFilter`에서 userEail를 추출하는 메서드인 `accessTokenExtractEmail`메서드를 `AccessToken`의 `email`클레임을 가저오도록 올바르게 수정하여 해당 문제를 해결했습니다.
(JWT토큰 타입이 `AccessToken`일 때 email을 가저와야 하지만 `RefreshToken`일 때 email를 가져오도록 로직을 작성했었습니다.)

### 한 일
- answer와 Improvement 저장로직 수행시 admin이 null인 버그 해결
- JWT인증 로직 code리펙토링

### 앞으로 할 일
- gradle 마이그레이션 진행한 `feature/gradlew-migration` branch를 `develop` branch에 pr 및 marge할 예정

build 성공했습니다.
![image](https://user-images.githubusercontent.com/62932968/131245116-c886a519-5f51-4146-88b9-d56c4e7a18f6.png)
