### PR TITLE
build script를 gradle용으로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ VOLUME /tmp
 EXPOSE 8080
 
 # The application's jar file
-ARG JAR_FILE=target/the-0.0.1-SNAPSHOT.jar
+ARG JAR_FILE=build/libs/the-0.0.1-SNAPSHOT.jar
 
 # Add the application's jar to the container
 ADD ${JAR_FILE} the_moment_server.jar

--- a/docker-compose-env.sh
+++ b/docker-compose-env.sh
@@ -1,15 +1,6 @@
 #!/bin/bash
-echo "====mvn clean======"
-./mvnw clean
-
-echo "=====mvn compile====="
-./mvnw compile
-
-echo "======mvn package======"
-./mvnw package
-
-echo "======docker-compose build======"
-docker-compose build
+echo "====gradle clean build======"
+./gradlew clean build
 
 echo "======docker-compose up======="
 docker-compose up


### PR DESCRIPTION
### 한일
- `docker-compose-env.sh`파일를 maven에서 gradle용으로 빌드스크립트 변경
- `Dockerfile`에서 프로젝트 build file위치 변경

### 스크립트 실행결과
<img width="1481" alt="스크린샷 2021-09-03 13 31 10" src="https://user-images.githubusercontent.com/62932968/131951054-50940493-a998-40c9-a7b8-510698b9afb1.png">
