### PR TITLE
UncomfortableEntity boardIdx변수명 uncomfortableIdx로 이름 변경

### DIFF
--- a/src/main/java/com/moment/the/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/moment/the/answer/repository/AnswerRepository.java
@@ -14,5 +14,5 @@ public interface AnswerRepository extends JpaRepository<AnswerDomain, Long> {
 
     Optional<AnswerDomain> findByAdminDomain(AdminDomain adminDomain);
 
-    AnswerDomain findTop1ByUncomfortableEntity_BoardIdx(Long boardIdx);
+    AnswerDomain findTop1ByUncomfortableEntity_uncomfortableIdx(Long uncomfortableIdx);
 }

--- a/src/main/java/com/moment/the/answer/service/AnswerService.java
+++ b/src/main/java/com/moment/the/answer/service/AnswerService.java
@@ -57,7 +57,7 @@ public class AnswerService {
 
     public AnswerResDto view(Long boardIdx) {
         // 해당 boardIdx를 참조하는 answerDomain 찾기.
-        AnswerDomain answerDomain = answerRepo.findTop1ByUncomfortableEntity_BoardIdx(boardIdx);
+        AnswerDomain answerDomain = answerRepo.findTop1ByUncomfortableEntity_uncomfortableIdx(boardIdx);
 
         AnswerResDto answerResDto = AnswerResDto.builder()
                 .answerIdx(answerDomain.getAnswerIdx())

--- a/src/main/java/com/moment/the/uncomfortable/UncomfortableEntity.java
+++ b/src/main/java/com/moment/the/uncomfortable/UncomfortableEntity.java
@@ -7,18 +7,17 @@ import javax.persistence.*;
 
 import static javax.persistence.FetchType.*;
 
-@Table(name = "Board")
-@Entity
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@Entity @Table(name = "Board")
+@Getter @Builder
+@NoArgsConstructor @AllArgsConstructor
 public class UncomfortableEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long boardIdx;
+    private Long uncomfortableIdx;
+
     @Column
     private String content;
+
     @Column
     private int goods;
 

--- a/src/main/java/com/moment/the/uncomfortable/UncomfortableEntity.java
+++ b/src/main/java/com/moment/the/uncomfortable/UncomfortableEntity.java
@@ -7,7 +7,7 @@ import javax.persistence.*;
 
 import static javax.persistence.FetchType.*;
 
-@Entity @Table(name = "Board")
+@Entity @Table(name = "uncomfortable")
 @Getter @Builder
 @NoArgsConstructor @AllArgsConstructor
 public class UncomfortableEntity {

--- a/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
+++ b/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
@@ -13,19 +13,19 @@ import java.util.Optional;
 @Repository
 public interface UncomfortableRepository extends JpaRepository<UncomfortableEntity, Long>{
     // idx로 uncomfortable 찾기.
-    Optional<UncomfortableEntity> findByBoardIdx(Long boardIdx);
+    Optional<UncomfortableEntity> findByUncomfortableIdx(Long uncomfortableIdx);
 
-    @Query(value = "SELECT COUNT(table.boardIdx) " +
+    @Query(value = "SELECT COUNT(table.uncomfortableIdx) " +
             "FROM UncomfortableEntity table" )
     Long amountUncomfortable();
 
-    @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableGetDto(table.boardIdx, table.content, table.goods, answer)" +
+    @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableGetDto(table.uncomfortableIdx, table.content, table.goods, answer)" +
             "FROM UncomfortableEntity table LEFT JOIN table.answerDomain answer " +
-            "ORDER BY table.boardIdx DESC "
+            "ORDER BY table.uncomfortableIdx DESC "
     )
     List<UncomfortableGetDto> uncomfortableViewAll();
 
-    @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableGetDto(table.boardIdx, table.content, table.goods, answer)" +
+    @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableGetDto(table.uncomfortableIdx, table.content, table.goods, answer)" +
             "FROM UncomfortableEntity table LEFT JOIN table.answerDomain answer " +
             "ORDER BY table.goods DESC "
     )

--- a/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
+++ b/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
@@ -51,14 +51,14 @@ public class UncomfortableService {
     // 좋아요 수 증가.
     @Transactional
     public void goods(Long boardIdx){
-        UncomfortableEntity uncomfortableEntity = uncomfortableRepository.findByBoardIdx(boardIdx).orElseThrow(NoPostException::new);
+        UncomfortableEntity uncomfortableEntity = uncomfortableRepository.findByUncomfortableIdx(boardIdx).orElseThrow(NoPostException::new);
         uncomfortableEntity.updateGoods(uncomfortableEntity.getGoods()+1);
     }
 
     // 좋아요 수 감소.
     @Transactional
     public void cancelGood(Long boardIdx) {
-        UncomfortableEntity uncomfortableEntity = uncomfortableRepository.findByBoardIdx(boardIdx).orElseThrow(NoPostException::new);
+        UncomfortableEntity uncomfortableEntity = uncomfortableRepository.findByUncomfortableIdx(boardIdx).orElseThrow(NoPostException::new);
         int goodsResult = uncomfortableEntity.getGoods() - 1;
 
         if(goodsResult > -1) {//좋야요가 양수일때

--- a/src/test/java/com/moment/the/controller/release/UncomfortableControllerTest.java
+++ b/src/test/java/com/moment/the/controller/release/UncomfortableControllerTest.java
@@ -155,7 +155,7 @@ class UncomfortableControllerTest {
         UncomfortableEntity uncomfortableEntity = UncomfortableEntity.builder()
                 .content("학교 급식이 맛이 없어요")
                 .build();
-        Long tableIdx = tableRepo.save(uncomfortableEntity).getBoardIdx();
+        Long tableIdx = tableRepo.save(uncomfortableEntity).getUncomfortableIdx();
 
         //When
         resultActions = mockMvc.perform(
@@ -177,7 +177,7 @@ class UncomfortableControllerTest {
                 .content("학교 급식이 맛이 없어요")
                 .goods(1)
                 .build();
-        Long tableIdx = tableRepo.save(uncomfortableEntity).getBoardIdx();
+        Long tableIdx = tableRepo.save(uncomfortableEntity).getUncomfortableIdx();
 
         //When
         resultActions = mockMvc.perform(

--- a/src/test/java/com/moment/the/service/AnswerServiceTest.java
+++ b/src/test/java/com/moment/the/service/AnswerServiceTest.java
@@ -89,7 +89,7 @@ class AnswerServiceTest {
         AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
 
         // When
-        AnswerDomain savedAnswer = answerService.save(answerDto, uncomfortableEntity.getBoardIdx());
+        AnswerDomain savedAnswer = answerService.save(answerDto, uncomfortableEntity.getUncomfortableIdx());
 
         // Then
         assertEquals(savedAnswer.getAnswerContent(), ANSWER_CONTENT);
@@ -112,14 +112,14 @@ class AnswerServiceTest {
         //answer 추가
         String ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
         AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
-        answerService.save(answerDto, uncomfortableEntity.getBoardIdx());
+        answerService.save(answerDto, uncomfortableEntity.getUncomfortableIdx());
 
         // When
         String ONCE_MORE_ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
         AnswerDto onceMoreAnswerDto = new AnswerDto(ONCE_MORE_ANSWER_CONTENT, null);
         AnswerAlreadyExistsException throwAtSaveMethod =
                 assertThrows(AnswerAlreadyExistsException.class,
-                        () -> answerService.save(onceMoreAnswerDto, uncomfortableEntity.getBoardIdx())
+                        () -> answerService.save(onceMoreAnswerDto, uncomfortableEntity.getUncomfortableIdx())
                 );
 
         // then
@@ -139,7 +139,7 @@ class AnswerServiceTest {
         // 답변 등록
         String ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
         AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
-        AnswerDomain savedAnswer = answerService.save(answerDto, uncomfortableEntity.getBoardIdx());
+        AnswerDomain savedAnswer = answerService.save(answerDto, uncomfortableEntity.getUncomfortableIdx());
         System.out.println("savedAnswer.getAnswerContent() = " + savedAnswer.getAnswerContent());
 
         // When
@@ -163,11 +163,11 @@ class AnswerServiceTest {
 
         String ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
         AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
-        AnswerDomain savedAnswer = answerService.save(answerDto, uncomfortableEntity.getBoardIdx());
+        AnswerDomain savedAnswer = answerService.save(answerDto, uncomfortableEntity.getUncomfortableIdx());
         System.out.println("savedAnswer.getAnswerContent() = " + savedAnswer.getAnswerContent());
 
         // When
-        AnswerResDto answerResDto = answerService.view(uncomfortableEntity.getBoardIdx());
+        AnswerResDto answerResDto = answerService.view(uncomfortableEntity.getUncomfortableIdx());
 
         //than
         assertEquals(answerResDto.getAnswerIdx(), savedAnswer.getAnswerIdx());
@@ -193,7 +193,7 @@ class AnswerServiceTest {
         // 답변 등록
         String ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
         AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
-        AnswerDomain savedAnswer = answerService.save(answerDto, uncomfortableEntity.getBoardIdx());
+        AnswerDomain savedAnswer = answerService.save(answerDto, uncomfortableEntity.getUncomfortableIdx());
 
         // When
         answerService.delete(savedAnswer.getAnswerIdx());
@@ -232,7 +232,7 @@ class AnswerServiceTest {
         // 답변 등록
         String ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
         AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
-        AnswerDomain savedAnswer = answerService.save(answerDto, uncomfortableEntity.getBoardIdx());
+        AnswerDomain savedAnswer = answerService.save(answerDto, uncomfortableEntity.getUncomfortableIdx());
 
         // When
         adminLogin(ADMIN_B_ID, ADMIN_B_PW);

--- a/src/test/java/com/moment/the/service/UncomfortableServiceTest.java
+++ b/src/test/java/com/moment/the/service/UncomfortableServiceTest.java
@@ -47,7 +47,7 @@ class UncomfortableServiceTest {
 
         // when
         UncomfortableEntity writeTable = uncomfortableService.write(uncomfortableSetDto);
-        UncomfortableEntity savedTable = tableRepo.findByBoardIdx(writeTable.getBoardIdx()).orElseThrow(() -> new IllegalArgumentException("Table을 찾을 수 없습니다. (테스트실패)"));
+        UncomfortableEntity savedTable = tableRepo.findByUncomfortableIdx(writeTable.getUncomfortableIdx()).orElseThrow(() -> new IllegalArgumentException("Table을 찾을 수 없습니다. (테스트실패)"));
         tableRepo.delete(savedTable);
 
         // then
@@ -143,8 +143,8 @@ class UncomfortableServiceTest {
 
         // When
         UncomfortableEntity savedUncomfortableEntity = tableRepo.save(uncomfortableEntity);
-        uncomfortableService.goods(savedUncomfortableEntity.getBoardIdx());
-        UncomfortableEntity savedGoodsUncomfortableEntity = tableRepo.findByBoardIdx(savedUncomfortableEntity.getBoardIdx()).orElseThrow(() -> new IllegalArgumentException("좋아요를 받은 TableEntity를 찾을 수 없습니다."));
+        uncomfortableService.goods(savedUncomfortableEntity.getUncomfortableIdx());
+        UncomfortableEntity savedGoodsUncomfortableEntity = tableRepo.findByUncomfortableIdx(savedUncomfortableEntity.getUncomfortableIdx()).orElseThrow(() -> new IllegalArgumentException("좋아요를 받은 TableEntity를 찾을 수 없습니다."));
 
         // Then
         assertEquals(savedGoodsUncomfortableEntity.getGoods(), 1);
@@ -161,8 +161,8 @@ class UncomfortableServiceTest {
 
         // When
         UncomfortableEntity savedUncomfortableEntity = tableRepo.save(uncomfortableEntity);
-        uncomfortableService.cancelGood(savedUncomfortableEntity.getBoardIdx());
-        UncomfortableEntity savedCancelGoodUncomfortableEntity = tableRepo.findByBoardIdx(savedUncomfortableEntity.getBoardIdx()).orElseThrow(() -> new IllegalArgumentException("좋아요를 취소한 TableEntity를 찾을 수 없습니다."));
+        uncomfortableService.cancelGood(savedUncomfortableEntity.getUncomfortableIdx());
+        UncomfortableEntity savedCancelGoodUncomfortableEntity = tableRepo.findByUncomfortableIdx(savedUncomfortableEntity.getUncomfortableIdx()).orElseThrow(() -> new IllegalArgumentException("좋아요를 취소한 TableEntity를 찾을 수 없습니다."));
 
         // Given
         assertEquals(savedCancelGoodUncomfortableEntity.getGoods(), 0);
@@ -179,10 +179,10 @@ class UncomfortableServiceTest {
 
         // When
         UncomfortableEntity savedUncomfortableEntity = tableRepo.save(uncomfortableEntity);
-        System.out.println(savedUncomfortableEntity.getBoardIdx());
+        System.out.println(savedUncomfortableEntity.getUncomfortableIdx());
 
         assertThrows(GoodsNotCancelException.class, () ->{
-            uncomfortableService.cancelGood(savedUncomfortableEntity.getBoardIdx());
+            uncomfortableService.cancelGood(savedUncomfortableEntity.getUncomfortableIdx());
         });
 
     }


### PR DESCRIPTION
### 한 일
- `UncomfortableEntity` Id변수명을 `BoardIdx`에서 `uncomfortableIdx`로 변경했습니다.
  > 그 과정에서 `AnswerRepository`, `UncomfortableRepositoryd`에서 JPQL변경 및 메서드 이름을 변경했습니다.

### 코드리뷰 원해요
- 올바르게 rename되었는지 + 변경으로 인한 로직 오류

### build 결과
![image](https://user-images.githubusercontent.com/62932968/132155647-8eb0ef49-c383-4623-a0fc-184ce3300449.png)
