### PR TITLE
Feature/rename last

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,9 +91,9 @@ jacoco {
 
 jacocoTestReport {
     reports {
-        html.enabled true
-        csv.enabled false
-        xml.enabled false
+        html.required = true
+        csv.required = false
+        xml.required = false
     }
     afterEvaluate {
         classDirectories.from = files(classDirectories.files.collect {

--- a/src/main/java/com/moment/the/admin/controller/AdminController.java
+++ b/src/main/java/com/moment/the/admin/controller/AdminController.java
@@ -31,7 +31,7 @@ public class AdminController {
 
     @PostMapping("/login")
     public SingleResult<Map<String, String>> login(@Valid @RequestBody SignInDto signInDto) throws Exception {
-        return responseService.getSingleResult(adminService.loginUser(signInDto.getAdminId(), signInDto.getAdminPwd()));
+        return responseService.getSingleResult(adminService.login(signInDto.getAdminId(), signInDto.getAdminPwd()));
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/moment/the/admin/service/AdminService.java
+++ b/src/main/java/com/moment/the/admin/service/AdminService.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public interface AdminService {
     void join(AdminDto adminDto) throws Exception;
-    Map<String, String> loginUser(String id, String password) throws Exception;
+    Map<String, String> login(String id, String password) throws Exception;
     void logout();
     void withdrawal(SignInDto SignInDto) throws Exception;
 }

--- a/src/main/java/com/moment/the/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/moment/the/admin/service/AdminServiceImpl.java
@@ -37,7 +37,7 @@ public class AdminServiceImpl implements AdminService {
     }
 
     @Override
-    public Map<String, String> loginUser(String id, String password) {
+    public Map<String, String> login(String id, String password) {
         // 아이디 검증
         AdminDomain adminDomain = adminRepository.findByAdminId(id);
         if (adminDomain == null) throw new UserNotFoundException();

--- a/src/main/java/com/moment/the/uncomfortable/controller/UncomfortableController.java
+++ b/src/main/java/com/moment/the/uncomfortable/controller/UncomfortableController.java
@@ -4,8 +4,8 @@ import com.moment.the.response.ResponseService;
 import com.moment.the.response.result.CommonResult;
 import com.moment.the.response.result.ListResult;
 import com.moment.the.response.result.SingleResult;
+import com.moment.the.uncomfortable.dto.UncomfortableResponseDto;
 import com.moment.the.uncomfortable.dto.UncomfortableSetDto;
-import com.moment.the.uncomfortable.dto.UncomfortableGetDto;
 import com.moment.the.uncomfortable.service.UncomfortableService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -38,7 +38,7 @@ public class UncomfortableController {
      * @author 전지환, 정시원
      */
     @GetMapping("/uncomfortable/rank")
-    public ListResult<UncomfortableGetDto> getRank(){
+    public ListResult<UncomfortableResponseDto> getRank(){
         return responseService.getListResult(uncomfortableService.getRank());
     }
 
@@ -48,7 +48,7 @@ public class UncomfortableController {
      * @author 전지환, 정시원
      */
     @GetMapping("/uncomfortable")
-    public ListResult<UncomfortableGetDto> getAllUncomfortable(){
+    public ListResult<UncomfortableResponseDto> getAllUncomfortable(){
         return responseService.getListResult(uncomfortableService.getAllUncomfortable());
     }
 

--- a/src/main/java/com/moment/the/uncomfortable/dto/UncomfortableResponseDto.java
+++ b/src/main/java/com/moment/the/uncomfortable/dto/UncomfortableResponseDto.java
@@ -6,14 +6,14 @@ import lombok.*;
 @Builder
 @Getter @Setter
 @NoArgsConstructor @AllArgsConstructor
-public class UncomfortableGetDto {
+public class UncomfortableResponseDto {
 
     private Long boardIdx;
     private String content;
     private int goods;
     private boolean isAnswer;
 
-    public UncomfortableGetDto(Long boardIdx, String content, int goods, AnswerDomain answer){
+    public UncomfortableResponseDto(Long boardIdx, String content, int goods, AnswerDomain answer){
         this.boardIdx = boardIdx;
         this.content = content;
         this.goods = goods;

--- a/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
+++ b/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
@@ -1,7 +1,7 @@
 package com.moment.the.uncomfortable.repository;
 
 import com.moment.the.uncomfortable.UncomfortableEntity;
-import com.moment.the.uncomfortable.dto.UncomfortableGetDto;
+import com.moment.the.uncomfortable.dto.UncomfortableResponseDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -19,15 +19,15 @@ public interface UncomfortableRepository extends JpaRepository<UncomfortableEnti
             "FROM UncomfortableEntity table" )
     Long amountUncomfortable();
 
-    @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableGetDto(table.boardIdx, table.content, table.goods, answer)" +
+    @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.boardIdx, table.content, table.goods, answer)" +
             "FROM UncomfortableEntity table LEFT JOIN table.answerDomain answer " +
             "ORDER BY table.boardIdx DESC "
     )
-    List<UncomfortableGetDto> uncomfortableViewAll();
+    List<UncomfortableResponseDto> uncomfortableViewAll();
 
-    @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableGetDto(table.boardIdx, table.content, table.goods, answer)" +
+    @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.boardIdx, table.content, table.goods, answer)" +
             "FROM UncomfortableEntity table LEFT JOIN table.answerDomain answer " +
             "ORDER BY table.goods DESC "
     )
-    List<UncomfortableGetDto> uncomfortableViewTopBy(Pageable p);
+    List<UncomfortableResponseDto> uncomfortableViewTopBy(Pageable p);
 }

--- a/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
+++ b/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
@@ -3,8 +3,8 @@ package com.moment.the.uncomfortable.service;
 import com.moment.the.exceptionAdvice.exception.GoodsNotCancelException;
 import com.moment.the.exceptionAdvice.exception.NoPostException;
 import com.moment.the.uncomfortable.UncomfortableEntity;
+import com.moment.the.uncomfortable.dto.UncomfortableResponseDto;
 import com.moment.the.uncomfortable.dto.UncomfortableSetDto;
-import com.moment.the.uncomfortable.dto.UncomfortableGetDto;
 import com.moment.the.uncomfortable.repository.UncomfortableRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,7 +36,7 @@ public class UncomfortableService {
      * 많은 학생들이 공감한 글 상위 30개를 선별하여 가져옵니다.
      * @return List<UncomfortableGetDto>
      */
-    public List<UncomfortableGetDto> getRank() {
+    public List<UncomfortableResponseDto> getRank() {
         return uncomfortableRepository.uncomfortableViewTopBy(PageRequest.of(0,30));
     }
 
@@ -44,7 +44,7 @@ public class UncomfortableService {
      * 학교의 불편함 전체를 가져옵니다.
      * @return List<UncomfortableGetDto>
      */
-    public List<UncomfortableGetDto> getAllUncomfortable(){
+    public List<UncomfortableResponseDto> getAllUncomfortable(){
         return uncomfortableRepository.uncomfortableViewAll();
     }
 

--- a/src/test/java/com/moment/the/controller/release/UncomfortableControllerTest.java
+++ b/src/test/java/com/moment/the/controller/release/UncomfortableControllerTest.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moment.the.uncomfortable.controller.UncomfortableController;
 import com.moment.the.uncomfortable.UncomfortableEntity;
 import com.moment.the.response.ResponseService;
+import com.moment.the.uncomfortable.dto.UncomfortableResponseDto;
 import com.moment.the.uncomfortable.dto.UncomfortableSetDto;
-import com.moment.the.uncomfortable.dto.UncomfortableGetDto;
 import com.moment.the.uncomfortable.repository.UncomfortableRepository;
 import com.moment.the.uncomfortable.service.UncomfortableService;
 import lombok.extern.slf4j.Slf4j;
@@ -134,8 +134,8 @@ class UncomfortableControllerTest {
         ).limit(40).collect(Collectors.toList());
 
         tableRepo.saveAll(uncomfortableEntities);
-        List<UncomfortableGetDto> uncomfortableGetDtos = uncomfortableService.getRank();
-        String top30Data = objectToJson(uncomfortableGetDtos);
+        List<UncomfortableResponseDto> uncomfortableResponseDtos = uncomfortableService.getRank();
+        String top30Data = objectToJson(uncomfortableResponseDtos);
 
         //When
         resultActions = mockMvc.perform(

--- a/src/test/java/com/moment/the/service/AdminServiceImplTest.java
+++ b/src/test/java/com/moment/the/service/AdminServiceImplTest.java
@@ -148,7 +148,7 @@ public class AdminServiceImplTest {
         adminRepository.save(adminDto.toEntity());
 
         //then
-        assertEquals(adminService.loginUser("s20062@gsmasdf","1234") == null, false);
+        assertEquals(adminService.login("s20062@gsmasdf","1234") == null, false);
     }
 
     @Test
@@ -204,7 +204,7 @@ public class AdminServiceImplTest {
 
         //When
         try {
-            adminServiceImpl.loginUser("admin@admin", "134");
+            adminServiceImpl.login("admin@admin", "134");
         } catch (UserNotFoundException e) {
             exceptionCatched = true;
         }

--- a/src/test/java/com/moment/the/service/UncomfortableServiceTest.java
+++ b/src/test/java/com/moment/the/service/UncomfortableServiceTest.java
@@ -2,8 +2,8 @@ package com.moment.the.service;
 
 import com.moment.the.exceptionAdvice.exception.GoodsNotCancelException;
 import com.moment.the.uncomfortable.*;
+import com.moment.the.uncomfortable.dto.UncomfortableResponseDto;
 import com.moment.the.uncomfortable.dto.UncomfortableSetDto;
-import com.moment.the.uncomfortable.dto.UncomfortableGetDto;
 import com.moment.the.uncomfortable.repository.UncomfortableRepository;
 import com.moment.the.uncomfortable.service.UncomfortableService;
 import org.junit.jupiter.api.AfterEach;
@@ -68,14 +68,14 @@ class UncomfortableServiceTest {
 
         // When
         tableRepo.saveAll(uncomfortableEntities);
-        List<UncomfortableGetDto> viewTop30 = uncomfortableService.getRank();
+        List<UncomfortableResponseDto> viewTop30 = uncomfortableService.getRank();
 
         // Then
         assertEquals(viewTop30.size(), 30);
         AtomicInteger j = new AtomicInteger(40);
         // TableService 의 top30View 로직이 올바르게 적용되면 j.get을 했을떄 값이 10이 나와야 한다.
         // 저장된Table - top30 = 40 - 30 = 10
-        for(UncomfortableGetDto v : viewTop30 ) {
+        for(UncomfortableResponseDto v : viewTop30 ) {
             assertEquals(v.getGoods(), j.getAndDecrement());
         }
         assertEquals(j.get(), 10);
@@ -93,7 +93,7 @@ class UncomfortableServiceTest {
 
         // When
         tableRepo.saveAll(uncomfortableEntities);
-        List<UncomfortableGetDto> tableViewAll = uncomfortableService.getAllUncomfortable();
+        List<UncomfortableResponseDto> tableViewAll = uncomfortableService.getAllUncomfortable();
 
         // Then
         assertEquals(tableViewAll.size(), 10); // 10개를 저장했으므로 tableViewAll 의 개수는 10개여야 한다.


### PR DESCRIPTION
### 한 일
1. `AdminService`의 `loginUser`메서드명를 `login`으로 변경했습니다.
  > `join`, `logout` 등 다른 `AdminService`의 메서드에 통일성을 위해
2. `UncomfortableGetDto`클래스명을  `UncomfortableResponseDto`로 변경했습니다.
  > Response 전용 DTO로 명시하기 위해
3. `build.gradle`에서 `Gradle 8.0`에서 `Deprecated`된 `enable`속성을 `required`속성으로 변경했습니다.
  참고 - [공식문서](https://docs.gradle.org/7.1.1/dsl/org.gradle.api.reporting.Report.html#org.gradle.api.reporting.Report:enabled)
![image](https://user-images.githubusercontent.com/62932968/133919647-82ba66ab-37ec-4f31-9503-7f6b4fd7f765.png)

