### PR TITLE
AdminDomain을 ERD에 맞게 변경했습니다.

### DIFF
--- a/src/main/java/com/moment/the/admin/AdminDomain.java
+++ b/src/main/java/com/moment/the/admin/AdminDomain.java
@@ -1,10 +1,7 @@
 package com.moment.the.admin;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,23 +12,23 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Entity
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Entity @Table(name = "admin")
+@Getter @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
 public class AdminDomain implements UserDetails {
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "admin_id")
     private Long adminIdx;
 
-    @Column(name = "name")
-    private String adminName;
-
     @Column(name = "email")
-    private String adminId;
+    private String email;
+
+    @Column(name = "name")
+    private String name;
 
     @Column(name = "password")
-    private String adminPwd;
+    private String password;
 
     @ElementCollection(fetch = FetchType.EAGER)
     @Builder.Default
@@ -46,13 +43,13 @@ public class AdminDomain implements UserDetails {
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Override
     public String getPassword() {
-        return this.adminPwd;
+        return this.password;
     }
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Override
     public String getUsername() {
-        return this.adminId;
+        return this.email;
     }
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)

--- a/src/main/java/com/moment/the/admin/controller/AdminController.java
+++ b/src/main/java/com/moment/the/admin/controller/AdminController.java
@@ -31,7 +31,7 @@ public class AdminController {
 
     @PostMapping("/login")
     public SingleResult<Map<String, String>> login(@Valid @RequestBody SignInDto signInDto) throws Exception {
-        return responseService.getSingleResult(adminService.login(signInDto.getAdminId(), signInDto.getAdminPwd()));
+        return responseService.getSingleResult(adminService.login(signInDto.getEmail(), signInDto.getPassword()));
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/moment/the/admin/dto/AdminDto.java
+++ b/src/main/java/com/moment/the/admin/dto/AdminDto.java
@@ -9,27 +9,25 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import java.util.Collections;
 
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
 public class AdminDto {
-    @Email(message = "Email should be valid")
-    @NotBlank(message = "id should be valid")
-    private String adminId;
+    @Email(message = "email should be valid")
+    @NotBlank(message = "email should be valid")
+    private String email;
 
     @NotBlank(message = "password should be valid")
-    private String adminPwd;
+    private String password;
 
     @NotBlank(message = "name should be valid")
     @Size(min = 3, max = 30)
-    private String adminName;
+    private String name;
 
     public AdminDomain toEntity() {
         return AdminDomain.builder()
-                .adminId(this.getAdminId())
-                .adminPwd(this.getAdminPwd())
-                .adminName(this.getAdminName())
+                .email(this.email)
+                .password(this.password)
+                .name(this.name)
                 .roles(Collections.singletonList("ROLE_ADMIN"))
                 .build();
     }

--- a/src/main/java/com/moment/the/admin/dto/SignInDto.java
+++ b/src/main/java/com/moment/the/admin/dto/SignInDto.java
@@ -11,14 +11,14 @@ import javax.validation.constraints.NotBlank;
 @NoArgsConstructor
 public class SignInDto {
     @NotBlank(message = "id should be valid")
-    private String adminId;
+    private String email;
     @NotBlank(message = "password should be valid")
-    private String adminPwd;
+    private String password;
 
     public AdminDomain toEntity(){
         return AdminDomain.builder()
-                .adminId(this.adminId)
-                .adminPwd(this.adminPwd)
+                .email(this.email)
+                .password(this.password)
                 .build();
     }
 }

--- a/src/main/java/com/moment/the/admin/repository/AdminRepository.java
+++ b/src/main/java/com/moment/the/admin/repository/AdminRepository.java
@@ -6,6 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AdminRepository extends JpaRepository<AdminDomain, Long> {
-    AdminDomain findByAdminId(String adminId);
-    AdminDomain findByAdminIdAndAdminPwd(String adminId, String password);
+    AdminDomain findByEmail(String email);
+    AdminDomain findByEmailAndPassword(String email, String password);
 }

--- a/src/main/java/com/moment/the/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/moment/the/admin/service/AdminServiceImpl.java
@@ -29,28 +29,28 @@ public class AdminServiceImpl implements AdminService {
 
     @Override
     public void join(AdminDto adminDto) {
-        if(adminRepository.findByAdminId(adminDto.getAdminId()) != null){
+        if(adminRepository.findByEmail(adminDto.getEmail()) != null){
             throw new UserAlreadyExistsException();
         }
-        adminDto.setAdminPwd(passwordEncoder.encode(adminDto.getAdminPwd()));
+        adminDto.setPassword(passwordEncoder.encode(adminDto.getPassword()));
         adminRepository.save(adminDto.toEntity());
     }
 
     @Override
     public Map<String, String> login(String id, String password) {
         // 아이디 검증
-        AdminDomain adminDomain = adminRepository.findByAdminId(id);
+        AdminDomain adminDomain = adminRepository.findByEmail(id);
         if (adminDomain == null) throw new UserNotFoundException();
         // 비밀번호 검증
         boolean passwordCheck = passwordEncoder.matches(password, adminDomain.getPassword());
         if (!passwordCheck) throw new UserNotFoundException();
 
-        final String accessToken = jwtUtil.generateAccessToken(adminDomain.getAdminId());
-        final String refreshJwt = jwtUtil.generateRefreshToken(adminDomain.getAdminId());
+        final String accessToken = jwtUtil.generateAccessToken(adminDomain.getEmail());
+        final String refreshJwt = jwtUtil.generateRefreshToken(adminDomain.getEmail());
         // token 만료 기간 설정
         redisUtil.setDataExpire(refreshJwt, adminDomain.getUsername(), JwtUtil.REFRESH_TOKEN_EXPIRATION_TIME);
         Map<String ,String> map = new HashMap<>();
-        map.put("id", adminDomain.getAdminId());
+        map.put("id", adminDomain.getEmail());
         map.put("accessToken", accessToken); // accessToken 반환
         map.put("refreshToken", refreshJwt); // refreshToken 반환
 
@@ -67,8 +67,8 @@ public class AdminServiceImpl implements AdminService {
     @Override
     public void withdrawal(SignInDto signInDto) throws Exception {
         // 로그인 된 이메일과 내가 삭제하려는 이메일이 같을 때.
-        if (getUserEmail().equals(signInDto.getAdminId())) {
-            AdminDomain adminDomain = adminRepository.findByAdminId(signInDto.getAdminId());
+        if (getUserEmail().equals(signInDto.getEmail())) {
+            AdminDomain adminDomain = adminRepository.findByEmail(signInDto.getEmail());
             adminRepository.delete(adminDomain);
         } else {
             throw new Exception("로그인 후 이용해주세요.");

--- a/src/main/java/com/moment/the/answer/service/AnswerService.java
+++ b/src/main/java/com/moment/the/answer/service/AnswerService.java
@@ -28,7 +28,7 @@ public class AnswerService {
         boolean existAnswer = uncomfortableEntity.getAnswerDomain() != null;
         if(existAnswer) throw new AnswerAlreadyExistsException(); //이미 답변이 있으면 Exception
 
-        AdminDomain adminDomain = adminRepo.findByAdminId(AdminServiceImpl.getUserEmail());
+        AdminDomain adminDomain = adminRepo.findByEmail(AdminServiceImpl.getUserEmail());
 
         // AnswerDomain 생성 및 Table 과의 연관관계 맻음
         answerDto.setAdminDomain(adminDomain);
@@ -45,7 +45,7 @@ public class AnswerService {
     public AnswerDomain updateThisAnswer(AnswerDto answerDto, Long answerIdx) {
         AnswerDomain answerDomain = answerFindBy(answerIdx); // 해당하는 answer 찾기
         AdminDomain answerAdmin = answerDomain.getAdminDomain();
-        AdminDomain loginAdmin = adminRepo.findByAdminId(AdminServiceImpl.getUserEmail());
+        AdminDomain loginAdmin = adminRepo.findByEmail(AdminServiceImpl.getUserEmail());
 
         answerOwnerCheck(answerAdmin, loginAdmin); // 자신이 작성한 답변인지 확인
 
@@ -63,7 +63,7 @@ public class AnswerService {
                 .answerIdx(answerDomain.getAnswerIdx())
                 .title(answerDomain.getUncomfortableEntity().getContent())
                 .content(answerDomain.getAnswerContent())
-                .writer(answerDomain.getAdminDomain().getAdminName())
+                .writer(answerDomain.getAdminDomain().getName())
                 .build();
 
         return answerResDto;
@@ -76,7 +76,7 @@ public class AnswerService {
         AnswerDomain answerDomain = answerFindBy(answerIdx);
         AdminDomain answerAdmin = answerDomain.getAdminDomain();
 
-        AdminDomain loginAdmin = adminRepo.findByAdminId(AdminServiceImpl.getUserEmail());
+        AdminDomain loginAdmin = adminRepo.findByEmail(AdminServiceImpl.getUserEmail());
         answerOwnerCheck(answerAdmin, loginAdmin); // 자신이 작성한 답변인지 확인
 
         // answer 삭제하기

--- a/src/main/java/com/moment/the/config/security/auth/MyUserDetailsService.java
+++ b/src/main/java/com/moment/the/config/security/auth/MyUserDetailsService.java
@@ -13,6 +13,6 @@ public class MyUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) {
-        return adminRepository.findByAdminId(email);
+        return adminRepository.findByEmail(email);
     }
 }

--- a/src/main/java/com/moment/the/improvement/service/ImprovementService.java
+++ b/src/main/java/com/moment/the/improvement/service/ImprovementService.java
@@ -27,7 +27,7 @@ public class ImprovementService {
     @Transactional
     public ImprovementDomain createThisImprovement(ImprovementDto improvementDto){
         try {
-            AdminDomain adminDomain = adminRepository.findByAdminId(AdminServiceImpl.getUserEmail());
+            AdminDomain adminDomain = adminRepository.findByEmail(AdminServiceImpl.getUserEmail());
             return improvementRepository.save(improvementDto.ToEntity(adminDomain));
         } catch (UserNotFoundException e){
             throw new UserNotFoundException();
@@ -47,7 +47,7 @@ public class ImprovementService {
     public void updateThisImprovement(ImprovementDto improvementDto, Long improveIdx){
         // 개선 사례 가져오기
         ImprovementDomain improvementDomain = improvementRepository.findByImproveIdx(improveIdx);
-        if(improvementDomain.getAdminDomain().getAdminId().equals(AdminServiceImpl.getUserEmail())){
+        if(improvementDomain.getAdminDomain().getEmail().equals(AdminServiceImpl.getUserEmail())){
             improvementDomain.update(improvementDto);
         } else {
             throw new AccessNotFoundException();
@@ -58,7 +58,7 @@ public class ImprovementService {
     @Transactional
     public void deleteThisImprovement(Long improveIdx){
         ImprovementDomain selectImprove = improvementRepository.findByImproveIdx(improveIdx);
-        if(selectImprove.getAdminDomain().getAdminId().equals(AdminServiceImpl.getUserEmail())){
+        if(selectImprove.getAdminDomain().getEmail().equals(AdminServiceImpl.getUserEmail())){
             improvementRepository.delete(selectImprove);
         } else {
             throw new AccessNotFoundException();

--- a/src/test/java/com/moment/the/improvement/service/ImprovementServiceTest.java
+++ b/src/test/java/com/moment/the/improvement/service/ImprovementServiceTest.java
@@ -44,10 +44,10 @@ class ImprovementServiceTest {
 
     // test 편의를 위한 로그인 매서드
     AdminDomain adminLogin(String adminId, String password) throws Exception {
-        AdminDomain adminDomain = adminRepository.findByAdminId(adminId);
+        AdminDomain adminDomain = adminRepository.findByEmail(adminId);
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
-                adminDomain.getAdminId(),
-                adminDomain.getAdminPwd(),
+                adminDomain.getEmail(),
+                adminDomain.getPassword(),
                 List.of(new SimpleGrantedAuthority("ROLE_USER")));
         SecurityContext context = SecurityContextHolder.getContext();
         context.setAuthentication(token);
@@ -74,7 +74,7 @@ class ImprovementServiceTest {
 
         //then
         assertEquals(false, improvementRepository.findByImproveContent("it's jihwan") == null);
-        assertEquals(true, improvementRepository.findByImproveContent("it's jihwan").getAdminDomain().getAdminId().equals("asdf@gsm"));
+        assertEquals(true, improvementRepository.findByImproveContent("it's jihwan").getAdminDomain().getEmail().equals("asdf@gsm"));
     }
 
 }

--- a/src/test/java/com/moment/the/service/AdminServiceImplTest.java
+++ b/src/test/java/com/moment/the/service/AdminServiceImplTest.java
@@ -46,15 +46,15 @@ public class AdminServiceImplTest {
         String pw = "1234";
 
         //when
-        adminDto.setAdminPwd(passwordEncoder.encode(pw));
-        adminDto.setAdminId(email);
-        adminDto.setAdminName(adminName);
+        adminDto.setPassword(passwordEncoder.encode(pw));
+        adminDto.setEmail(email);
+        adminDto.setName(adminName);
         adminRepository.save(adminDto.toEntity());
 
         //then
-        assertEquals(adminDto.getAdminId(), email);
-        assertEquals(passwordEncoder.matches(pw,adminDto.getAdminPwd()), true);
-        assertEquals(adminDto.getAdminName(), "jihwan");
+        assertEquals(adminDto.getEmail(), email);
+        assertEquals(passwordEncoder.matches(pw,adminDto.getPassword()), true);
+        assertEquals(adminDto.getName(), "jihwan");
     }
 
     @Test
@@ -63,13 +63,13 @@ public class AdminServiceImplTest {
         AdminDto adminDto = new AdminDto();
         String alreadyEmail = "asdf@asdf";
         String email = "asdf@asdf";
-        adminDto.setAdminId(alreadyEmail);
+        adminDto.setEmail(alreadyEmail);
 
         //when
         adminRepository.save(adminDto.toEntity());
 
         //then
-        assertEquals(adminRepository.findByAdminId(email) == null , false);
+        assertEquals(adminRepository.findByEmail(email) == null , false);
 
     }
 
@@ -79,19 +79,19 @@ public class AdminServiceImplTest {
         AdminDto adminDto = new AdminDto();
 
         String id = "s20062@gsm";
-        adminDto.setAdminId(id);
+        adminDto.setEmail(id);
 
         String pw = "1234";
-        adminDto.setAdminPwd(passwordEncoder.encode(pw));
+        adminDto.setPassword(passwordEncoder.encode(pw));
 
         adminRepository.save(adminDto.toEntity());
 
         //when
-        if(adminRepository.findByAdminId(id) == null){
+        if(adminRepository.findByEmail(id) == null){
             throw new UserNotFoundException();
         } else {
             // then
-            assertEquals(passwordEncoder.matches(pw, adminDto.getAdminPwd()), true);
+            assertEquals(passwordEncoder.matches(pw, adminDto.getPassword()), true);
         }
     }
 
@@ -101,15 +101,15 @@ public class AdminServiceImplTest {
         AdminDto adminDto = new AdminDto();
         String userEmail = "s20062@gsm";
         String pw = "1234";
-        adminDto.setAdminId(userEmail);
-        adminDto.setAdminPwd(passwordEncoder.encode(pw));
+        adminDto.setEmail(userEmail);
+        adminDto.setPassword(passwordEncoder.encode(pw));
         adminRepository.save(adminDto.toEntity());
         System.out.println("======== saved =========");
 
         // when login session 발급
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
-                adminDto.getAdminId(),
-                adminDto.getAdminPwd(),
+                adminDto.getEmail(),
+                adminDto.getPassword(),
                 List.of(new SimpleGrantedAuthority("ROLE_USER")));
         SecurityContext context = SecurityContextHolder.getContext();
         context.setAuthentication(token);
@@ -125,24 +125,24 @@ public class AdminServiceImplTest {
     void 서비스_회원가입() throws Exception {
         //Given
         AdminDto adminDto = new AdminDto();
-        adminDto.setAdminId("s20062@gsm");
-        adminDto.setAdminPwd("1234");
-        adminDto.setAdminName("jihwan");
+        adminDto.setEmail("s20062@gsm");
+        adminDto.setPassword("1234");
+        adminDto.setName("jihwan");
 
         //when
         adminService.join(adminDto);
 
         //then
-        assertEquals(adminRepository.findByAdminId("s20062@gsm") != null, true);
+        assertEquals(adminRepository.findByEmail("s20062@gsm") != null, true);
     }
 
     @Test @Disabled
     void 서비스_로그인() throws Exception {
         //Given
         AdminDto adminDto = new AdminDto();
-        adminDto.setAdminId("s20062@gsmasdf");
-        adminDto.setAdminPwd(passwordEncoder.encode("1234"));
-        adminDto.setAdminName("jihwan");
+        adminDto.setEmail("s20062@gsmasdf");
+        adminDto.setPassword(passwordEncoder.encode("1234"));
+        adminDto.setName("jihwan");
 
         //when
         adminRepository.save(adminDto.toEntity());
@@ -155,22 +155,22 @@ public class AdminServiceImplTest {
     void 회원탈퇴() throws Exception {
         // Given 회원가입
         AdminDto adminDto = new AdminDto();
-        adminDto.setAdminName("jihwan");
-        adminDto.setAdminId("s20062@gsm");
-        adminDto.setAdminPwd(passwordEncoder.encode("1234"));
+        adminDto.setName("jihwan");
+        adminDto.setEmail("s20062@gsm");
+        adminDto.setPassword(passwordEncoder.encode("1234"));
         adminRepository.save(adminDto.toEntity());
         System.out.println("=========is saved=========");
 
         // Given SignInDto
         SignInDto signInDto = new SignInDto();
-        signInDto.setAdminId("s20062@gsm");
-        signInDto.setAdminPwd("1234");
+        signInDto.setEmail("s20062@gsm");
+        signInDto.setPassword("1234");
         System.out.println("======== is set ========");
 
         // when login session 발급
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
-                adminDto.getAdminId(),
-                adminDto.getAdminPwd(),
+                adminDto.getEmail(),
+                adminDto.getPassword(),
                 List.of(new SimpleGrantedAuthority("ROLE_USER")));
         SecurityContext context = SecurityContextHolder.getContext();
         context.setAuthentication(token);
@@ -198,8 +198,8 @@ public class AdminServiceImplTest {
         boolean exceptionCatched = false;
 
         AdminDto adminDto = new AdminDto();
-        adminDto.setAdminId("admin@admin");
-        adminDto.setAdminPwd(passwordEncoder.encode("1234"));
+        adminDto.setEmail("admin@admin");
+        adminDto.setPassword(passwordEncoder.encode("1234"));
         adminRepository.save(adminDto.toEntity());
 
         //When
@@ -219,15 +219,15 @@ public class AdminServiceImplTest {
         AdminDto adminDto = new AdminDto();
         String userEmail = "s20062@gsm";
         String pw = "1234";
-        adminDto.setAdminId(userEmail);
-        adminDto.setAdminPwd(passwordEncoder.encode(pw));
+        adminDto.setEmail(userEmail);
+        adminDto.setPassword(passwordEncoder.encode(pw));
         adminRepository.save(adminDto.toEntity());
         System.out.println("======== saved =========");
 
         // when login session 발급
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
-                adminDto.getAdminId(),
-                adminDto.getAdminPwd(),
+                adminDto.getEmail(),
+                adminDto.getPassword(),
                 List.of(new SimpleGrantedAuthority("ROLE_USER")));
         SecurityContext context = SecurityContextHolder.getContext();
         context.setAuthentication(token);

--- a/src/test/java/com/moment/the/service/AnswerServiceTest.java
+++ b/src/test/java/com/moment/the/service/AnswerServiceTest.java
@@ -53,10 +53,10 @@ class AnswerServiceTest {
 
     //test 편의를 위한 로그인 매서드
     AdminDomain adminLogin(String adminId, String password) {
-        AdminDomain adminDomain = adminRepo.findByAdminIdAndAdminPwd(adminId, password);
+        AdminDomain adminDomain = adminRepo.findByEmailAndPassword(adminId, password);
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
-                adminDomain.getAdminId(),
-                adminDomain.getAdminPwd(),
+                adminDomain.getEmail(),
+                adminDomain.getPassword(),
                 List.of(new SimpleGrantedAuthority("ROLE_USER")));
         SecurityContext context = SecurityContextHolder.getContext();
         context.setAuthentication(token);
@@ -172,7 +172,7 @@ class AnswerServiceTest {
         //than
         assertEquals(answerResDto.getAnswerIdx(), savedAnswer.getAnswerIdx());
         assertEquals(answerResDto.getTitle(), savedAnswer.getUncomfortableEntity().getContent());
-        assertEquals(answerResDto.getWriter(), savedAnswer.getAdminDomain().getAdminName());
+        assertEquals(answerResDto.getWriter(), savedAnswer.getAdminDomain().getName());
         assertEquals(answerResDto.getContent(), savedAnswer.getAnswerContent());
     }
 

--- a/src/test/java/com/moment/the/service/ImprovementServiceTest.java
+++ b/src/test/java/com/moment/the/service/ImprovementServiceTest.java
@@ -51,10 +51,10 @@ public class ImprovementServiceTest {
 
     // test 편의를 위한 로그인 매서드
     AdminDomain adminLogin(String adminId, String password) throws Exception {
-        AdminDomain adminDomain = adminRepository.findByAdminId(adminId);
+        AdminDomain adminDomain = adminRepository.findByEmail(adminId);
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
-                adminDomain.getAdminId(),
-                adminDomain.getAdminPwd(),
+                adminDomain.getEmail(),
+                adminDomain.getPassword(),
                 List.of(new SimpleGrantedAuthority("ROLE_USER")));
         SecurityContext context = SecurityContextHolder.getContext();
         context.setAuthentication(token);


### PR DESCRIPTION
#### `AdminDomain`을 ERD에 맞게 필드명과 DB에 매핑되는 `@Column` 속성의 `name`을 변경했습니다.
![image](https://user-images.githubusercontent.com/62932968/133920439-8248a67a-e55f-48d9-bd11-4c6ef9081ab7.png)

`AdminDomain`를 변경하면서 이에 의존하는 다른 로직들도 변경되었습니다.
- `AdminRepository`의 쿼리메소드
- Builder패턴을 사용해 `AdminDomain`를 생성하는 `AdminDto`, `SignInDto`
- 그 이외 `AdminDomain`의 getter를 사용하는 로직들

### 코드리뷰 원해요 :)
1. 더 나은 필드, 메서드, 클래스명 제안
2. 누락된 내용 있을 시 피드백