### PR TITLE
Rename Erd에 맞게 UncomfortableDomain변경

### DIFF
--- a/src/main/java/com/moment/the/answer/AnswerDomain.java
+++ b/src/main/java/com/moment/the/answer/AnswerDomain.java
@@ -4,7 +4,7 @@ package com.moment.the.answer;
 
 import com.moment.the.admin.AdminDomain;
 import com.moment.the.answer.dto.AnswerDto;
-import com.moment.the.uncomfortable.UncomfortableEntity;
+import com.moment.the.uncomfortable.UncomfortableDomain;
 import com.sun.istack.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,7 +33,7 @@ public class AnswerDomain {
 
     @OneToOne(mappedBy = "answerDomain", fetch = LAZY)
     @JoinColumn(name = "boardIdx", nullable = false)
-    private UncomfortableEntity uncomfortableEntity;
+    private UncomfortableDomain uncomfortableDomain;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name="writer", nullable = false)
@@ -44,8 +44,8 @@ public class AnswerDomain {
         this.answerContent = answerDto.getContent();
     }
 
-    public void updateTableDomain(UncomfortableEntity uncomfortableEntity){
-        this.uncomfortableEntity = uncomfortableEntity;
-        this.uncomfortableEntity.updateAnswerDomain(this);
+    public void updateTableDomain(UncomfortableDomain uncomfortableDomain){
+        this.uncomfortableDomain = uncomfortableDomain;
+        this.uncomfortableDomain.updateAnswerDomain(this);
     }
 }

--- a/src/main/java/com/moment/the/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/moment/the/answer/repository/AnswerRepository.java
@@ -14,5 +14,5 @@ public interface AnswerRepository extends JpaRepository<AnswerDomain, Long> {
 
     Optional<AnswerDomain> findByAdminDomain(AdminDomain adminDomain);
 
-    AnswerDomain findTop1ByUncomfortableEntity_BoardIdx(Long boardIdx);
+    AnswerDomain findTop1ByUncomfortableDomain_uncomfortableIdx(Long uncomfortableIdx);
 }

--- a/src/main/java/com/moment/the/answer/service/AnswerService.java
+++ b/src/main/java/com/moment/the/answer/service/AnswerService.java
@@ -8,7 +8,7 @@ import com.moment.the.answer.dto.AnswerDto;
 import com.moment.the.answer.dto.AnswerResDto;
 import com.moment.the.answer.repository.AnswerRepository;
 import com.moment.the.exceptionAdvice.exception.*;
-import com.moment.the.uncomfortable.UncomfortableEntity;
+import com.moment.the.uncomfortable.UncomfortableDomain;
 import com.moment.the.uncomfortable.repository.UncomfortableRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,8 +24,8 @@ public class AnswerService {
     // 답변 작성하기
     public AnswerDomain createThisAnswer(AnswerDto answerDto, Long boardIdx) {
         //예외 처리
-        UncomfortableEntity uncomfortableEntity = tableFindBy(boardIdx); // table 번호로 찾고 없으면 Exception
-        boolean existAnswer = uncomfortableEntity.getAnswerDomain() != null;
+        UncomfortableDomain uncomfortableDomain = tableFindBy(boardIdx); // table 번호로 찾고 없으면 Exception
+        boolean existAnswer = uncomfortableDomain.getAnswerDomain() != null;
         if(existAnswer) throw new AnswerAlreadyExistsException(); //이미 답변이 있으면 Exception
 
         AdminDomain adminDomain = adminRepo.findByEmail(AdminServiceImpl.getUserEmail());
@@ -33,7 +33,7 @@ public class AnswerService {
         // AnswerDomain 생성 및 Table 과의 연관관계 맻음
         answerDto.setAdminDomain(adminDomain);
         AnswerDomain saveAnswerDomain = answerDto.toEntity();
-        saveAnswerDomain.updateTableDomain(uncomfortableEntity);
+        saveAnswerDomain.updateTableDomain(uncomfortableDomain);
 
         AnswerDomain savedAnswerDomain = answerRepo.save(saveAnswerDomain);
 
@@ -57,11 +57,11 @@ public class AnswerService {
 
     public AnswerResDto getThisAnswer(Long boardIdx) {
         // 해당 boardIdx를 참조하는 answerDomain 찾기.
-        AnswerDomain answerDomain = answerRepo.findTop1ByUncomfortableEntity_BoardIdx(boardIdx);
+        AnswerDomain answerDomain = answerRepo.findTop1ByUncomfortableDomain_uncomfortableIdx(boardIdx);
 
         AnswerResDto answerResDto = AnswerResDto.builder()
                 .answerIdx(answerDomain.getAnswerIdx())
-                .title(answerDomain.getUncomfortableEntity().getContent())
+                .title(answerDomain.getUncomfortableDomain().getContent())
                 .content(answerDomain.getAnswerContent())
                 .writer(answerDomain.getAdminDomain().getName())
                 .build();
@@ -94,13 +94,13 @@ public class AnswerService {
     }
 
     // tableIdx 로 해당 table 찾기
-    public UncomfortableEntity tableFindBy(Long tableId){
+    public UncomfortableDomain tableFindBy(Long tableId){
         return tableRepo.findById(tableId).orElseThrow(NoPostException::new);
     }
 
     public void deleteAnswer(AnswerDomain answerDomain){
         Long answerIdx = answerDomain.getAnswerIdx();
-        answerDomain.getUncomfortableEntity().updateAnswerDomain(null); // 외래키 제약조건으로 인한 오류 해결
+        answerDomain.getUncomfortableDomain().updateAnswerDomain(null); // 외래키 제약조건으로 인한 오류 해결
         answerRepo.deleteAllByAnswerIdx(answerIdx);
     }
 

--- a/src/main/java/com/moment/the/uncomfortable/UncomfortableDomain.java
+++ b/src/main/java/com/moment/the/uncomfortable/UncomfortableDomain.java
@@ -7,20 +7,21 @@ import javax.persistence.*;
 
 import static javax.persistence.FetchType.*;
 
-@Table(name = "Board")
-@Entity
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class UncomfortableEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long boardIdx;
-    @Column
+@Entity @Table(name = "uncomfortable")
+@Getter @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED) @AllArgsConstructor
+public class UncomfortableDomain {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "uncomfortable_id")
+    private Long uncomfortableIdx;
+
+    @Column(name = "content")
     private String content;
-    @Column
+
+    @Column(name = "goods")
     private int goods;
+
     @OneToOne(fetch = LAZY, cascade = CascadeType.ALL)
     private AnswerDomain answerDomain;
 

--- a/src/main/java/com/moment/the/uncomfortable/dto/UncomfortableSetDto.java
+++ b/src/main/java/com/moment/the/uncomfortable/dto/UncomfortableSetDto.java
@@ -1,6 +1,6 @@
 package com.moment.the.uncomfortable.dto;
 
-import com.moment.the.uncomfortable.UncomfortableEntity;
+import com.moment.the.uncomfortable.UncomfortableDomain;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,8 +16,8 @@ public class UncomfortableSetDto {
     @NotBlank
     private String content;
 
-    public UncomfortableEntity toEntity(){
-        return UncomfortableEntity.builder()
+    public UncomfortableDomain toEntity(){
+        return UncomfortableDomain.builder()
                 .content(this.content)
                 .build();
     }

--- a/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
+++ b/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
@@ -1,6 +1,6 @@
 package com.moment.the.uncomfortable.repository;
 
-import com.moment.the.uncomfortable.UncomfortableEntity;
+import com.moment.the.uncomfortable.UncomfortableDomain;
 import com.moment.the.uncomfortable.dto.UncomfortableResponseDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,22 +11,22 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface UncomfortableRepository extends JpaRepository<UncomfortableEntity, Long>{
+public interface UncomfortableRepository extends JpaRepository<UncomfortableDomain, Long>{
 
-    Optional<UncomfortableEntity> findByBoardIdx(Long boardIdx);
+    Optional<UncomfortableDomain> findByUncomfortableIdx(Long UncomfortableIdx);
 
-    @Query(value = "SELECT COUNT(table.boardIdx) " +
-            "FROM UncomfortableEntity table" )
+    @Query(value = "SELECT COUNT(table.uncomfortableIdx) " +
+            "FROM UncomfortableDomain table" )
     Long amountUncomfortable();
 
-    @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.boardIdx, table.content, table.goods, answer)" +
-            "FROM UncomfortableEntity table LEFT JOIN table.answerDomain answer " +
-            "ORDER BY table.boardIdx DESC "
+    @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.uncomfortableIdx, table.content, table.goods, answer)" +
+            "FROM UncomfortableDomain table LEFT JOIN table.answerDomain answer " +
+            "ORDER BY table.uncomfortableIdx DESC "
     )
     List<UncomfortableResponseDto> uncomfortableViewAll();
 
-    @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.boardIdx, table.content, table.goods, answer)" +
-            "FROM UncomfortableEntity table LEFT JOIN table.answerDomain answer " +
+    @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.uncomfortableIdx, table.content, table.goods, answer)" +
+            "FROM UncomfortableDomain table LEFT JOIN table.answerDomain answer " +
             "ORDER BY table.goods DESC "
     )
     List<UncomfortableResponseDto> uncomfortableViewTopBy(Pageable p);

--- a/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
+++ b/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
@@ -2,7 +2,7 @@ package com.moment.the.uncomfortable.service;
 
 import com.moment.the.exceptionAdvice.exception.GoodsNotCancelException;
 import com.moment.the.exceptionAdvice.exception.NoPostException;
-import com.moment.the.uncomfortable.UncomfortableEntity;
+import com.moment.the.uncomfortable.UncomfortableDomain;
 import com.moment.the.uncomfortable.dto.UncomfortableResponseDto;
 import com.moment.the.uncomfortable.dto.UncomfortableSetDto;
 import com.moment.the.uncomfortable.repository.UncomfortableRepository;
@@ -28,7 +28,7 @@ public class UncomfortableService {
      * @return UncomfortableEntity
      */
     @Transactional
-    public UncomfortableEntity createThisUncomfortable(UncomfortableSetDto uncomfortableSetDto){
+    public UncomfortableDomain createThisUncomfortable(UncomfortableSetDto uncomfortableSetDto){
         return uncomfortableRepository.save(uncomfortableSetDto.toEntity());
     }
 
@@ -54,8 +54,8 @@ public class UncomfortableService {
      */
     @Transactional
     public void increaseLike(Long boardIdx){
-        UncomfortableEntity uncomfortableEntity = uncomfortableRepository.findByBoardIdx(boardIdx).orElseThrow(NoPostException::new);
-        uncomfortableEntity.updateGoods(uncomfortableEntity.getGoods()+1);
+        UncomfortableDomain uncomfortableDomain = uncomfortableRepository.findByUncomfortableIdx(boardIdx).orElseThrow(NoPostException::new);
+        uncomfortableDomain.updateGoods(uncomfortableDomain.getGoods()+1);
     }
 
     /**
@@ -64,11 +64,11 @@ public class UncomfortableService {
      */
     @Transactional
     public void decreaseLike(Long boardIdx) {
-        UncomfortableEntity uncomfortableEntity = uncomfortableRepository.findByBoardIdx(boardIdx).orElseThrow(NoPostException::new);
-        int goodsResult = uncomfortableEntity.getGoods() - 1;
+        UncomfortableDomain uncomfortableDomain = uncomfortableRepository.findByUncomfortableIdx(boardIdx).orElseThrow(NoPostException::new);
+        int goodsResult = uncomfortableDomain.getGoods() - 1;
 
         if(goodsResult > -1) {//좋야요가 양수일때
-            uncomfortableEntity.updateGoods(goodsResult);
+            uncomfortableDomain.updateGoods(goodsResult);
         }else{
             throw new GoodsNotCancelException();
         }

--- a/src/test/java/com/moment/the/controller/release/UncomfortableControllerTest.java
+++ b/src/test/java/com/moment/the/controller/release/UncomfortableControllerTest.java
@@ -2,8 +2,8 @@ package com.moment.the.controller.release;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moment.the.uncomfortable.UncomfortableDomain;
 import com.moment.the.uncomfortable.controller.UncomfortableController;
-import com.moment.the.uncomfortable.UncomfortableEntity;
 import com.moment.the.response.ResponseService;
 import com.moment.the.uncomfortable.dto.UncomfortableResponseDto;
 import com.moment.the.uncomfortable.dto.UncomfortableSetDto;
@@ -99,8 +99,8 @@ class UncomfortableControllerTest {
                 .collect(Collectors.toList());
 
         AtomicInteger i = new AtomicInteger(0);
-        List<UncomfortableEntity> uncomfortableEntities = Stream.generate(
-                () -> UncomfortableEntity.builder()
+        List<UncomfortableDomain> uncomfortableEntities = Stream.generate(
+                () -> UncomfortableDomain.builder()
                         .goods(0)
                         .content(TABLE_CONTENTS.get(i.getAndIncrement()))
                         .build()
@@ -126,8 +126,8 @@ class UncomfortableControllerTest {
     void top30_검증() throws Exception {
         //Given
         AtomicInteger i = new AtomicInteger(1);
-        List<UncomfortableEntity> uncomfortableEntities = Stream.generate(
-                () -> UncomfortableEntity.builder()
+        List<UncomfortableDomain> uncomfortableEntities = Stream.generate(
+                () -> UncomfortableDomain.builder()
                         .goods(i.getAndIncrement())
                         .content(RandomStringUtils.randomAlphabetic(15))
                         .build()
@@ -152,10 +152,10 @@ class UncomfortableControllerTest {
     @Test @DisplayName("[PUT]/v1/uncomfortable/{boardIdx} goods 추가")
     void goods_검증() throws Exception {
         //Given
-        UncomfortableEntity uncomfortableEntity = UncomfortableEntity.builder()
+        UncomfortableDomain uncomfortableDomain = UncomfortableDomain.builder()
                 .content("학교 급식이 맛이 없어요")
                 .build();
-        Long tableIdx = tableRepo.save(uncomfortableEntity).getBoardIdx();
+        Long tableIdx = tableRepo.save(uncomfortableDomain).getUncomfortableIdx();
 
         //When
         resultActions = mockMvc.perform(
@@ -173,11 +173,11 @@ class UncomfortableControllerTest {
     @Test @DisplayName("[PUT]/v1/uncomfortable/cancel/{boardIdx} goods 감소")
     void goodCancel_검증() throws Exception {
         //Given
-        UncomfortableEntity uncomfortableEntity = UncomfortableEntity.builder()
+        UncomfortableDomain uncomfortableDomain = UncomfortableDomain.builder()
                 .content("학교 급식이 맛이 없어요")
                 .goods(1)
                 .build();
-        Long tableIdx = tableRepo.save(uncomfortableEntity).getBoardIdx();
+        Long tableIdx = tableRepo.save(uncomfortableDomain).getUncomfortableIdx();
 
         //When
         resultActions = mockMvc.perform(
@@ -195,8 +195,8 @@ class UncomfortableControllerTest {
     @Test @DisplayName("[GET]/v1/uncomfortable/amount ")
     void amountUncomfortable_검증() throws Exception {
         //Given
-        List<UncomfortableEntity> uncomfortableEntities = Stream.generate(
-                () -> UncomfortableEntity.builder()
+        List<UncomfortableDomain> uncomfortableEntities = Stream.generate(
+                () -> UncomfortableDomain.builder()
                         .content(RandomStringUtils.randomAlphabetic(15))
                         .build()
         ).limit(8).collect(Collectors.toList());

--- a/src/test/java/com/moment/the/service/AnswerServiceTest.java
+++ b/src/test/java/com/moment/the/service/AnswerServiceTest.java
@@ -9,7 +9,7 @@ import com.moment.the.answer.repository.AnswerRepository;
 import com.moment.the.answer.service.AnswerService;
 import com.moment.the.config.security.auth.MyUserDetailsService;
 import com.moment.the.admin.AdminDomain;
-import com.moment.the.uncomfortable.UncomfortableEntity;
+import com.moment.the.uncomfortable.UncomfortableDomain;
 import com.moment.the.admin.dto.AdminDto;
 import com.moment.the.uncomfortable.dto.UncomfortableSetDto;
 import com.moment.the.admin.repository.AdminRepository;
@@ -65,11 +65,11 @@ class AnswerServiceTest {
     }
 
     //test 편의를 위한 Table 생성 메서드
-    UncomfortableEntity createTable(){
+    UncomfortableDomain createTable(){
         String TABLE_CONTENT = "급식이 맛이 없어요 급식에 질을 높여주세요!";
         UncomfortableSetDto uncomfortableSetDto = new UncomfortableSetDto(TABLE_CONTENT);
-        UncomfortableEntity uncomfortableEntity = uncomfortableService.createThisUncomfortable(uncomfortableSetDto);
-        return uncomfortableEntity;
+        UncomfortableDomain uncomfortableDomain = uncomfortableService.createThisUncomfortable(uncomfortableSetDto);
+        return uncomfortableDomain;
     }
 
     @Test @DisplayName("답변 작성하기 (save) 검증")
@@ -82,18 +82,18 @@ class AnswerServiceTest {
         AdminDomain adminDomain = adminLogin(USER_ID, USER_PASSWORD);
 
         //Table 등록
-        UncomfortableEntity uncomfortableEntity = createTable();
+        UncomfortableDomain uncomfortableDomain = createTable();
 
         //answer 입력
         String ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
         AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
 
         // When
-        AnswerDomain savedAnswer = answerService.createThisAnswer(answerDto, uncomfortableEntity.getBoardIdx());
+        AnswerDomain savedAnswer = answerService.createThisAnswer(answerDto, uncomfortableDomain.getUncomfortableIdx());
 
         // Then
         assertEquals(savedAnswer.getAnswerContent(), ANSWER_CONTENT);
-        assertEquals(savedAnswer.getUncomfortableEntity(), uncomfortableEntity);
+        assertEquals(savedAnswer.getUncomfortableDomain(), uncomfortableDomain);
         assertEquals(savedAnswer.getAdminDomain(), adminDomain);
     }
 
@@ -107,19 +107,19 @@ class AnswerServiceTest {
         AdminDomain adminDomain = adminLogin(USER_ID, USER_PASSWORD);
 
         //Table 등록
-        UncomfortableEntity uncomfortableEntity = createTable();
+        UncomfortableDomain uncomfortableDomain = createTable();
 
         //answer 추가
         String ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
         AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
-        answerService.createThisAnswer(answerDto, uncomfortableEntity.getBoardIdx());
+        answerService.createThisAnswer(answerDto, uncomfortableDomain.getUncomfortableIdx());
 
         // When
         String ONCE_MORE_ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
         AnswerDto onceMoreAnswerDto = new AnswerDto(ONCE_MORE_ANSWER_CONTENT, null);
         AnswerAlreadyExistsException throwAtSaveMethod =
                 assertThrows(AnswerAlreadyExistsException.class,
-                        () -> answerService.createThisAnswer(onceMoreAnswerDto, uncomfortableEntity.getBoardIdx())
+                        () -> answerService.createThisAnswer(onceMoreAnswerDto, uncomfortableDomain.getUncomfortableIdx())
                 );
 
         // then
@@ -134,12 +134,12 @@ class AnswerServiceTest {
 
         //로그인
         adminLogin(USER_ID, USER_PASSWORD);
-        UncomfortableEntity uncomfortableEntity = createTable();
+        UncomfortableDomain uncomfortableDomain = createTable();
 
         // 답변 등록
         String ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
         AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
-        AnswerDomain savedAnswer = answerService.createThisAnswer(answerDto, uncomfortableEntity.getBoardIdx());
+        AnswerDomain savedAnswer = answerService.createThisAnswer(answerDto, uncomfortableDomain.getUncomfortableIdx());
         System.out.println("savedAnswer.getAnswerContent() = " + savedAnswer.getAnswerContent());
 
         // When
@@ -155,7 +155,7 @@ class AnswerServiceTest {
     @Test @DisplayName("답변 보기 (view) 검증")
     void view_검증() throws Exception {
         // Given
-        UncomfortableEntity uncomfortableEntity = createTable();
+        UncomfortableDomain uncomfortableDomain = createTable();
 
         // 답변 등록
         adminSignUp(USER_ID, USER_PASSWORD, USER_NAME); // 답변 등록을 위한 회원가입
@@ -163,15 +163,15 @@ class AnswerServiceTest {
 
         String ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
         AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
-        AnswerDomain savedAnswer = answerService.createThisAnswer(answerDto, uncomfortableEntity.getBoardIdx());
+        AnswerDomain savedAnswer = answerService.createThisAnswer(answerDto, uncomfortableDomain.getUncomfortableIdx());
         System.out.println("savedAnswer.getAnswerContent() = " + savedAnswer.getAnswerContent());
 
         // When
-        AnswerResDto answerResDto = answerService.getThisAnswer(uncomfortableEntity.getBoardIdx());
+        AnswerResDto answerResDto = answerService.getThisAnswer(uncomfortableDomain.getUncomfortableIdx());
 
         //than
         assertEquals(answerResDto.getAnswerIdx(), savedAnswer.getAnswerIdx());
-        assertEquals(answerResDto.getTitle(), savedAnswer.getUncomfortableEntity().getContent());
+        assertEquals(answerResDto.getTitle(), savedAnswer.getUncomfortableDomain().getContent());
         assertEquals(answerResDto.getWriter(), savedAnswer.getAdminDomain().getName());
         assertEquals(answerResDto.getContent(), savedAnswer.getAnswerContent());
     }
@@ -188,12 +188,12 @@ class AnswerServiceTest {
 
         //로그인
         adminLogin(USER_ID, USER_PASSWORD);
-        UncomfortableEntity uncomfortableEntity = createTable();
+        UncomfortableDomain uncomfortableDomain = createTable();
 
         // 답변 등록
         String ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
         AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
-        AnswerDomain savedAnswer = answerService.createThisAnswer(answerDto, uncomfortableEntity.getBoardIdx());
+        AnswerDomain savedAnswer = answerService.createThisAnswer(answerDto, uncomfortableDomain.getUncomfortableIdx());
 
         // When
         answerService.deleteThisAnswer(savedAnswer.getAnswerIdx());
@@ -227,12 +227,12 @@ class AnswerServiceTest {
 
         adminSignUp("adminB", "adminB_PW", "adminB");
 
-        UncomfortableEntity uncomfortableEntity = createTable();
+        UncomfortableDomain uncomfortableDomain = createTable();
 
         // 답변 등록
         String ANSWER_CONTENT = "급식이 맛이 없는 이유는 삼식이라 어쩔수 없어요~";
         AnswerDto answerDto = new AnswerDto(ANSWER_CONTENT, null);
-        AnswerDomain savedAnswer = answerService.createThisAnswer(answerDto, uncomfortableEntity.getBoardIdx());
+        AnswerDomain savedAnswer = answerService.createThisAnswer(answerDto, uncomfortableDomain.getUncomfortableIdx());
 
         // When
         adminLogin(ADMIN_B_ID, ADMIN_B_PW);

--- a/src/test/java/com/moment/the/service/UncomfortableServiceTest.java
+++ b/src/test/java/com/moment/the/service/UncomfortableServiceTest.java
@@ -46,8 +46,8 @@ class UncomfortableServiceTest {
                 .build();
 
         // when
-        UncomfortableEntity writeTable = uncomfortableService.createThisUncomfortable(uncomfortableSetDto);
-        UncomfortableEntity savedTable = tableRepo.findByBoardIdx(writeTable.getBoardIdx()).orElseThrow(() -> new IllegalArgumentException("Table을 찾을 수 없습니다. (테스트실패)"));
+        UncomfortableDomain writeTable = uncomfortableService.createThisUncomfortable(uncomfortableSetDto);
+        UncomfortableDomain savedTable = tableRepo.findByUncomfortableIdx(writeTable.getUncomfortableIdx()).orElseThrow(() -> new IllegalArgumentException("Table을 찾을 수 없습니다. (테스트실패)"));
         tableRepo.delete(savedTable);
 
         // then
@@ -59,8 +59,8 @@ class UncomfortableServiceTest {
     void TableService_top30View_검증(){
         // Given
         AtomicInteger i = new AtomicInteger(1);
-        List<UncomfortableEntity> uncomfortableEntities = Stream.generate(
-                () -> UncomfortableEntity.builder()
+        List<UncomfortableDomain> uncomfortableEntities = Stream.generate(
+                () -> UncomfortableDomain.builder()
                         .goods(i.getAndIncrement())
                         .content("TableService top30 보여주기 테스트")
                         .build()
@@ -85,8 +85,8 @@ class UncomfortableServiceTest {
     @DisplayName("TableService viewAll 검증")
     void TableService_viewAll_검증(){
         // Given
-        List<UncomfortableEntity> uncomfortableEntities = Stream.generate(
-                () -> UncomfortableEntity.builder()
+        List<UncomfortableDomain> uncomfortableEntities = Stream.generate(
+                () -> UncomfortableDomain.builder()
                         .content("TableService viewAll 검증")
                         .build()
         ).limit(10).collect(Collectors.toList());
@@ -105,8 +105,8 @@ class UncomfortableServiceTest {
     @DisplayName("TableService 전체 개시글 수 보여주기 (amountUncomfortableView)검증")
     void TableService_amountUncomfortableView_검증(){
         // Given
-        List<UncomfortableEntity> uncomfortableEntities = Stream.generate(
-                () -> UncomfortableEntity.builder()
+        List<UncomfortableDomain> uncomfortableEntities = Stream.generate(
+                () -> UncomfortableDomain.builder()
                         .content("TableService amountUncomfortableView 검증")
                         .build()
         ).limit(10).collect(Collectors.toList());
@@ -137,52 +137,52 @@ class UncomfortableServiceTest {
     @DisplayName("TableService 좋아요 수 증가 로직 (goods) 검증")
     void TableService_goods_검증(){
         // Given
-        UncomfortableEntity uncomfortableEntity = UncomfortableEntity.builder()
+        UncomfortableDomain uncomfortableDomain = UncomfortableDomain.builder()
                 .content("TableService_goods_검증")
                 .build();
 
         // When
-        UncomfortableEntity savedUncomfortableEntity = tableRepo.save(uncomfortableEntity);
-        uncomfortableService.increaseLike(savedUncomfortableEntity.getBoardIdx());
-        UncomfortableEntity savedGoodsUncomfortableEntity = tableRepo.findByBoardIdx(savedUncomfortableEntity.getBoardIdx()).orElseThrow(() -> new IllegalArgumentException("좋아요를 받은 TableEntity를 찾을 수 없습니다."));
+        UncomfortableDomain savedUncomfortableDomain = tableRepo.save(uncomfortableDomain);
+        uncomfortableService.increaseLike(savedUncomfortableDomain.getUncomfortableIdx());
+        UncomfortableDomain savedGoodsUncomfortableDomain = tableRepo.findByUncomfortableIdx(savedUncomfortableDomain.getUncomfortableIdx()).orElseThrow(() -> new IllegalArgumentException("좋아요를 받은 TableEntity를 찾을 수 없습니다."));
 
         // Then
-        assertEquals(savedGoodsUncomfortableEntity.getGoods(), 1);
+        assertEquals(savedGoodsUncomfortableDomain.getGoods(), 1);
     }
 
     @Test
     @DisplayName("TableService 좋아요 수 감소 로직 (cancelGood) 검증")
     void TableService_cancelGood_검증(){
         // Given
-        UncomfortableEntity uncomfortableEntity = UncomfortableEntity.builder()
+        UncomfortableDomain uncomfortableDomain = UncomfortableDomain.builder()
                 .content("TableService_goods_검증")
                 .goods(1) // 좋아요 한개 지급
                 .build();
 
         // When
-        UncomfortableEntity savedUncomfortableEntity = tableRepo.save(uncomfortableEntity);
-        uncomfortableService.decreaseLike(savedUncomfortableEntity.getBoardIdx());
-        UncomfortableEntity savedCancelGoodUncomfortableEntity = tableRepo.findByBoardIdx(savedUncomfortableEntity.getBoardIdx()).orElseThrow(() -> new IllegalArgumentException("좋아요를 취소한 TableEntity를 찾을 수 없습니다."));
+        UncomfortableDomain savedUncomfortableDomain = tableRepo.save(uncomfortableDomain);
+        uncomfortableService.decreaseLike(savedUncomfortableDomain.getUncomfortableIdx());
+        UncomfortableDomain savedCancelGoodUncomfortableDomain = tableRepo.findByUncomfortableIdx(savedUncomfortableDomain.getUncomfortableIdx()).orElseThrow(() -> new IllegalArgumentException("좋아요를 취소한 TableEntity를 찾을 수 없습니다."));
 
         // Given
-        assertEquals(savedCancelGoodUncomfortableEntity.getGoods(), 0);
+        assertEquals(savedCancelGoodUncomfortableDomain.getGoods(), 0);
     }
 
     @Test
     @DisplayName("TableService 좋아요 수 감소 로직 (cancelGood) 음수가 될경우 exception 검증")
     void TableService_cancelGood_exception_검증() throws Exception {
         // Given
-        UncomfortableEntity uncomfortableEntity = UncomfortableEntity.builder()
+        UncomfortableDomain uncomfortableDomain = UncomfortableDomain.builder()
                 .content("TableService_goods_검증")
                 .goods(0) // 좋아요 0개
                 .build();
 
         // When
-        UncomfortableEntity savedUncomfortableEntity = tableRepo.save(uncomfortableEntity);
-        System.out.println(savedUncomfortableEntity.getBoardIdx());
+        UncomfortableDomain savedUncomfortableDomain = tableRepo.save(uncomfortableDomain);
+        System.out.println(savedUncomfortableDomain.getUncomfortableIdx());
 
         assertThrows(GoodsNotCancelException.class, () ->{
-            uncomfortableService.decreaseLike(savedUncomfortableEntity.getBoardIdx());
+            uncomfortableService.decreaseLike(savedUncomfortableDomain.getUncomfortableIdx());
         });
 
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/62932968/133936899-b9949211-b68b-4a01-b3ed-4ff242edb46c.png)

1. `UncomfortableEntity`를 `UncomfortableDomain`로 이름을 변경했습니다.
    > 이유: class 명 통일화

2. Erd에 맞게 `AnswerDomain`객체 필드를 변경했습니다.
    변경하면서 `AnswerDomain`, `AnswerRepository`, `AnswerService`, `UncomfortableSetDto`, `UncomfortableRepository`, `UncomfortableService`, 그 외 test를 변경 했습니다. 
