### PR TITLE
querydsl configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,10 @@ plugins {
     id 'org.springframework.boot' version '2.4.2'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'jacoco'
+
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
+    // *** Q-Type error 때문에 추가 *** //
+    id "io.franzbecker.gradle-lombok" version "3.0.0"
 }
 
 repositories {
@@ -63,6 +67,25 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
 
     compileOnly 'org.springframework.boot:spring-boot-starter-tomcat'
+
+    // *** querydsl *** //
+    implementation 'com.querydsl:querydsl-jpa'
+}
+
+//querydsl
+def querydslDir = "$buildDir/generated/querydsl" as String
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main.java.srcDir querydslDir
+}
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }
 
 test {

--- a/src/main/java/com/moment/the/config/querydsl/QuerydslConfiguration.java
+++ b/src/main/java/com/moment/the/config/querydsl/QuerydslConfiguration.java
@@ -1,0 +1,21 @@
+package com.moment.the.config.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfiguration {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(em);
+    }
+
+}


### PR DESCRIPTION
### 한 일
- querydsl에 대한 의존성을 추가했습니다.
- querydsl의 `JPAQueryFactory`를 IoC에서 관리하게 해서 어디서나 DI받아 사용할 수 있게 설정했습니다.