### PR TITLE
UncomfortableService.getNumberOfUncomfortable에서 사용하던 amountUncomfortable()를 count()로 변경

### DIFF
--- a/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
+++ b/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
@@ -15,10 +15,6 @@ public interface UncomfortableRepository extends JpaRepository<UncomfortableDoma
 
     Optional<UncomfortableDomain> findByUncomfortableIdx(Long UncomfortableIdx);
 
-    @Query(value = "SELECT COUNT(table.uncomfortableIdx) " +
-            "FROM UncomfortableDomain table" )
-    Long amountUncomfortable();
-
     @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.uncomfortableIdx, table.content, table.goods, answer)" +
             "FROM UncomfortableDomain table LEFT JOIN table.answerDomain answer " +
             "ORDER BY table.uncomfortableIdx DESC "

--- a/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
+++ b/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
@@ -86,6 +86,7 @@ public class UncomfortableService {
     /**
      * 불편함의 개수를 세어 가져옵니다.
      * @return Long
+     * @author 정시원, 전지환
      */
     public Long getNumberOfUncomfortable(){
         return uncomfortableRepository.count();

--- a/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
+++ b/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
@@ -88,7 +88,7 @@ public class UncomfortableService {
      * @return Long
      */
     public Long getNumberOfUncomfortable(){
-        return uncomfortableRepository.amountUncomfortable();
+        return uncomfortableRepository.count();
     }
 
     /**


### PR DESCRIPTION
### 한 일
Uncomfortable의 컬럼 개수를 가져오는 `UncomfortableRepository`.`amountUncomfortable`를 제거 하고 `UncomfortableService.getNumberOfUncomfortable`에서 DataJpa에서 제공하는 `count`매서드를 사용했습니다.

`amountUncomfortable`를 jpql로 구현했던 이유는 DataJpa에 `count`라는 매서드의 여부를 알지 못해서 사용했습니다. 
 이번에 querydsl 으로 이전하면서 구글링을 하던 중 `amountUncomfortable`와 기능이 똑같은 DataJpa의 `count`를 발견해 수정후 pr날립니다.