### PR TITLE
jpql -> querydsl이전 완료

### DIFF
--- a/src/main/java/com/moment/the/uncomfortable/dto/UncomfortableResponseDto.java
+++ b/src/main/java/com/moment/the/uncomfortable/dto/UncomfortableResponseDto.java
@@ -1,6 +1,5 @@
 package com.moment.the.uncomfortable.dto;
 
-import com.moment.the.answer.AnswerDomain;
 import lombok.*;
 
 @Builder
@@ -12,12 +11,4 @@ public class UncomfortableResponseDto {
     private String content;
     private int goods;
     private boolean isAnswer;
-
-    public UncomfortableResponseDto(Long boardIdx, String content, int goods, AnswerDomain answer){
-        this.boardIdx = boardIdx;
-        this.content = content;
-        this.goods = goods;
-        this.isAnswer = answer != null;
-    }
-
 }

--- a/src/main/java/com/moment/the/uncomfortable/dto/UncomfortableResponseDto.java
+++ b/src/main/java/com/moment/the/uncomfortable/dto/UncomfortableResponseDto.java
@@ -1,14 +1,22 @@
 package com.moment.the.uncomfortable.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
-@Builder
-@Getter @Setter
-@NoArgsConstructor @AllArgsConstructor
+@Builder @Getter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL) //null인 필드를 제외합니다.
 public class UncomfortableResponseDto {
 
-    private Long boardIdx;
+    private Long uncomfortableIdx;
     private String content;
     private int goods;
-    private boolean isAnswer;
+
+    private Boolean isAnswer; // rank API에서만 사용한다.
+
+    public UncomfortableResponseDto(Long uncomfortableIdx, String content, int goods){
+        this.uncomfortableIdx = uncomfortableIdx;
+        this.content = content;
+        this.goods = goods;
+    }
 }

--- a/src/main/java/com/moment/the/uncomfortable/dto/UncomfortableResponseDto.java
+++ b/src/main/java/com/moment/the/uncomfortable/dto/UncomfortableResponseDto.java
@@ -1,8 +1,15 @@
 package com.moment.the.uncomfortable.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.moment.the.uncomfortable.repository.UncomfortableCustomRepositoryImpl;
 import lombok.*;
 
+/**
+ * 사용자에게 전달되는 Response용 DTO이다.<br>
+ * {@link isAnswer}는 APi에 따라서 불필요할 수 있다. (ex. 불편한순간 전체보기API)
+ * @since 1.0.0
+ * @author 정시원
+ */
 @Builder @Getter
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL) //null인 필드를 제외합니다.
@@ -14,6 +21,14 @@ public class UncomfortableResponseDto {
 
     private Boolean isAnswer; // rank API에서만 사용한다.
 
+    /**
+     * {@link UncomfortableCustomRepositoryImpl#uncomfortableViewAll()}에서 생성자 Projection에 필요하다.
+     * @param uncomfortableIdx UncomfortableDomain의 idx
+     * @param content UncomfortableDomain의 내용
+     * @param goods UncomfortableDomain의 좋아요 개수
+     * @see UncomfortableCustomRepositoryImpl#uncomfortableViewAll()
+     * @author 정시원
+     */
     public UncomfortableResponseDto(Long uncomfortableIdx, String content, int goods){
         this.uncomfortableIdx = uncomfortableIdx;
         this.content = content;

--- a/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableCustomRepository.java
+++ b/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableCustomRepository.java
@@ -16,8 +16,8 @@ import java.util.List;
 public interface UncomfortableCustomRepository {
 
     /**
-     * 불편한순간(uncomfortable)를 모두 조회하여 {@link UncomfortableResponseDto}로 변환하여 반환합니다.
-     * @return List&#60;UncomfortableResponseDto&#62; - 불편한순간를 모두 조회하여 나온 View전용 List
+     * UncomfortableDomain를 모두 조회하여 {@link UncomfortableResponseDto}로 변환하여 반환합니다.
+     * @return List&#60;UncomfortableResponseDto&#62; UncomfortableDomain를 UncomfortableResponseDto로 변환한 리스트
      * @author 정시원
      */
     List<UncomfortableResponseDto> uncomfortableViewAll();

--- a/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableCustomRepository.java
+++ b/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableCustomRepository.java
@@ -1,0 +1,32 @@
+package com.moment.the.uncomfortable.repository;
+
+import com.moment.the.uncomfortable.dto.UncomfortableResponseDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+/**
+ * querydsl를 사용하기 위한 UncomfortableRepository의 CustomRepository
+ * @author 정시원
+ * @since 1.1.2
+ * @version 1.1.2
+ */
+public interface UncomfortableCustomRepository {
+
+    /**
+     * 불편한순간(uncomfortable)를 모두 조회하여 {@link UncomfortableResponseDto}로 변환하여 반환합니다.
+     * @return List&#60;UncomfortableResponseDto&#62; - 불편한순간를 모두 조회하여 나온 View전용 List
+     * @author 정시원
+     */
+    List<UncomfortableResponseDto> uncomfortableViewAll();
+
+    /**
+     * 불편한순간(Uncomfortable)에 좋아요 개수가 많은 순으로 정렬해 limit개의 결과를 반환합니다.
+     * @param limit 조회결과 제한 개수
+     * @return List&#60;UncomfortableResponseDto&#62; - 불편한순간를 모두 조회하여 나온 View전용 List
+     * @author 정시원
+     */
+    List<UncomfortableResponseDto> uncomfortableViewTopBy(int limit);
+}

--- a/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableCustomRepositoryImpl.java
+++ b/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableCustomRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.moment.the.uncomfortable.repository;
 
 import com.moment.the.uncomfortable.dto.UncomfortableResponseDto;
+import com.querydsl.core.types.Order;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -44,17 +45,22 @@ public class UncomfortableCustomRepositoryImpl implements UncomfortableCustomRep
 
     /**
      * 불편한순간(Uncomfortable)에 좋아요 개수가 많은 순으로 정렬해 limit개의 결과를 반환합니다.
-     * TODO 기존 JPQL를 querydsl로 이전하기
-     *     @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.uncomfortableIdx, table.content, table.goods, answer)" +
-     *             "FROM UncomfortableDomain table LEFT JOIN table.answerDomain answer " +
-     *             "ORDER BY table.goods DESC "
-     *     )
      * @param limit 조회결과 제한 개수
      * @return List&#60;UncomfortableResponseDto&#62; - 불편한순간를 랭크순으로 조회하여 나온 View전용 List
      * @author 정시원
      */
     @Override
     public List<UncomfortableResponseDto> uncomfortableViewTopBy(int limit) {
-        return null;
+        return queryFactory
+                .from(uncomfortableDomain)
+                .select(Projections.constructor(UncomfortableResponseDto.class,
+                        uncomfortableDomain.uncomfortableIdx,
+                        uncomfortableDomain.content,
+                        uncomfortableDomain.goods,
+                        uncomfortableDomain.answerDomain.isNotNull()
+                ))
+                .limit(limit)
+                .orderBy(uncomfortableDomain.goods.desc())
+                .fetch();
     }
 }

--- a/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableCustomRepositoryImpl.java
+++ b/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableCustomRepositoryImpl.java
@@ -31,15 +31,13 @@ public class UncomfortableCustomRepositoryImpl implements UncomfortableCustomRep
      * @author 정시원
      */
     @Override
-    @Transactional()
     public List<UncomfortableResponseDto> uncomfortableViewAll() {
         return queryFactory
                 .from(uncomfortableDomain)
-                .select(Projections.constructor(UncomfortableResponseDto.class,
+                .select(Projections.constructor(UncomfortableResponseDto.class, // 생성자를 통해 DTO로 select한다.
                     uncomfortableDomain.uncomfortableIdx,
                     uncomfortableDomain.content,
-                    uncomfortableDomain.goods,
-                    uncomfortableDomain.answerDomain.isNotNull()
+                    uncomfortableDomain.goods
                 )
         ).fetch();
     }

--- a/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableCustomRepositoryImpl.java
+++ b/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableCustomRepositoryImpl.java
@@ -1,8 +1,11 @@
 package com.moment.the.uncomfortable.repository;
 
 import com.moment.the.uncomfortable.dto.UncomfortableResponseDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.criterion.Projection;
 import org.springframework.stereotype.Repository;
 
 import javax.transaction.Transactional;
@@ -23,19 +26,22 @@ public class UncomfortableCustomRepositoryImpl implements UncomfortableCustomRep
     private final JPAQueryFactory queryFactory;
 
     /**
-     * 불편한순간(uncomfortable)를 모두 조회하여 {@link UncomfortableResponseDto}로 변환하여 반환합니다.
-     * TODO 기존 JPQL를 querydsl로 이전하기
-     *     @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.uncomfortableIdx, table.content, table.goods, answer)" +
-     *             "FROM UncomfortableDomain table LEFT JOIN table.answerDomain answer " +
-     *             "ORDER BY table.uncomfortableIdx DESC "
-     *     )
-     *     List<UncomfortableResponseDto> uncomfortableViewAll();
-     * @return List&#60;UncomfortableResponseDto&#62; - 불편한순간를 모두 조회하여 나온 View전용 List
+     * UncomfortableDomain를 모두 조회하여 {@link UncomfortableResponseDto}로 변환하여 반환합니다.
+     * @return List&#60;UncomfortableResponseDto&#62; UncomfortableDomain를 UncomfortableResponseDto로 변환한 리스트
      * @author 정시원
      */
     @Override
+    @Transactional()
     public List<UncomfortableResponseDto> uncomfortableViewAll() {
-        return null;
+        return queryFactory
+                .from(uncomfortableDomain)
+                .select(Projections.constructor(UncomfortableResponseDto.class,
+                    uncomfortableDomain.uncomfortableIdx,
+                    uncomfortableDomain.content,
+                    uncomfortableDomain.goods,
+                    uncomfortableDomain.answerDomain.isNotNull()
+                )
+        ).fetch();
     }
 
     /**

--- a/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableCustomRepositoryImpl.java
+++ b/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableCustomRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.moment.the.uncomfortable.repository;
+
+import com.moment.the.uncomfortable.dto.UncomfortableResponseDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.transaction.Transactional;
+
+import java.util.List;
+
+import static com.moment.the.uncomfortable.QUncomfortableDomain.uncomfortableDomain;
+
+/**
+ * querydsl를 사용하기 위한 UncomfortableRepository의 CustomRepository구현체
+ * @author 정시원
+ * @since 1.1.2
+ * @version 1.1.2
+ */
+@RequiredArgsConstructor
+public class UncomfortableCustomRepositoryImpl implements UncomfortableCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 불편한순간(uncomfortable)를 모두 조회하여 {@link UncomfortableResponseDto}로 변환하여 반환합니다.
+     * TODO 기존 JPQL를 querydsl로 이전하기
+     *     @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.uncomfortableIdx, table.content, table.goods, answer)" +
+     *             "FROM UncomfortableDomain table LEFT JOIN table.answerDomain answer " +
+     *             "ORDER BY table.uncomfortableIdx DESC "
+     *     )
+     *     List<UncomfortableResponseDto> uncomfortableViewAll();
+     * @return List&#60;UncomfortableResponseDto&#62; - 불편한순간를 모두 조회하여 나온 View전용 List
+     * @author 정시원
+     */
+    @Override
+    public List<UncomfortableResponseDto> uncomfortableViewAll() {
+        return null;
+    }
+
+    /**
+     * 불편한순간(Uncomfortable)에 좋아요 개수가 많은 순으로 정렬해 limit개의 결과를 반환합니다.
+     * TODO 기존 JPQL를 querydsl로 이전하기
+     *     @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.uncomfortableIdx, table.content, table.goods, answer)" +
+     *             "FROM UncomfortableDomain table LEFT JOIN table.answerDomain answer " +
+     *             "ORDER BY table.goods DESC "
+     *     )
+     * @param limit 조회결과 제한 개수
+     * @return List&#60;UncomfortableResponseDto&#62; - 불편한순간를 랭크순으로 조회하여 나온 View전용 List
+     * @author 정시원
+     */
+    @Override
+    public List<UncomfortableResponseDto> uncomfortableViewTopBy(int limit) {
+        return null;
+    }
+}

--- a/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
+++ b/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
@@ -13,10 +13,6 @@ public interface UncomfortableRepository extends JpaRepository<UncomfortableDoma
 
     Optional<UncomfortableDomain> findByUncomfortableIdx(Long UncomfortableIdx);
 
-    @Query(value = "SELECT COUNT(table.uncomfortableIdx) " +
-            "FROM UncomfortableDomain table" )
-    Long amountUncomfortable();
-
     @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.uncomfortableIdx, table.content, table.goods, answer)" +
             "FROM UncomfortableDomain table LEFT JOIN table.answerDomain answer " +
             "ORDER BY table.uncomfortableIdx DESC "

--- a/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
+++ b/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
@@ -13,6 +13,10 @@ public interface UncomfortableRepository extends JpaRepository<UncomfortableDoma
 
     Optional<UncomfortableDomain> findByUncomfortableIdx(Long UncomfortableIdx);
 
+    @Query(value = "SELECT COUNT(table.uncomfortableIdx) " +
+            "FROM UncomfortableDomain table" )
+    Long amountUncomfortable();
+
     @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.uncomfortableIdx, table.content, table.goods, answer)" +
             "FROM UncomfortableDomain table LEFT JOIN table.answerDomain answer " +
             "ORDER BY table.uncomfortableIdx DESC "

--- a/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
+++ b/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
@@ -1,12 +1,9 @@
 package com.moment.the.uncomfortable.repository;
 
 import com.moment.the.uncomfortable.UncomfortableDomain;
-import com.moment.the.uncomfortable.dto.UncomfortableResponseDto;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface UncomfortableRepository extends JpaRepository<UncomfortableDomain, Long>, UncomfortableCustomRepository{
@@ -16,16 +13,4 @@ public interface UncomfortableRepository extends JpaRepository<UncomfortableDoma
     @Query(value = "SELECT COUNT(table.uncomfortableIdx) " +
             "FROM UncomfortableDomain table" )
     Long amountUncomfortable();
-
-    @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.uncomfortableIdx, table.content, table.goods, answer)" +
-            "FROM UncomfortableDomain table LEFT JOIN table.answerDomain answer " +
-            "ORDER BY table.uncomfortableIdx DESC "
-    )
-    List<UncomfortableResponseDto> uncomfortableViewAll();
-
-    @Query("SELECT new com.moment.the.uncomfortable.dto.UncomfortableResponseDto(table.uncomfortableIdx, table.content, table.goods, answer)" +
-            "FROM UncomfortableDomain table LEFT JOIN table.answerDomain answer " +
-            "ORDER BY table.goods DESC "
-    )
-    List<UncomfortableResponseDto> uncomfortableViewTopBy(Pageable p);
 }

--- a/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
+++ b/src/main/java/com/moment/the/uncomfortable/repository/UncomfortableRepository.java
@@ -5,13 +5,11 @@ import com.moment.the.uncomfortable.dto.UncomfortableResponseDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
-@Repository
-public interface UncomfortableRepository extends JpaRepository<UncomfortableDomain, Long>{
+public interface UncomfortableRepository extends JpaRepository<UncomfortableDomain, Long>, UncomfortableCustomRepository{
 
     Optional<UncomfortableDomain> findByUncomfortableIdx(Long UncomfortableIdx);
 

--- a/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
+++ b/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
@@ -33,7 +33,7 @@ public class UncomfortableService {
 
     /**
      * 많은 학생들이 공감한 글 상위 30개를 선별하여 가져옵니다.
-     * @return List<UncomfortableGetDto>
+     * @return List&#60;UncomfortableGetDto&#62;
      * @author 정시원, 전지환
      */
     public List<UncomfortableResponseDto> getRank() {
@@ -42,7 +42,7 @@ public class UncomfortableService {
 
     /**
      * 학교의 불편함 전체를 가져옵니다.
-     * @return List<UncomfortableGetDto>
+     * @return List&#60;UncomfortableGetDto&#62;
      * @author 정시원, 전지환
      */
     public List<UncomfortableResponseDto> getAllUncomfortable(){
@@ -77,11 +77,11 @@ public class UncomfortableService {
 
     /**
      * 해당 불편함을 삭제합니다.
-     * @param boardIdx
+     * @param uncomfortableIdx
      */
     @Transactional
-    public void deleteThisUncomfortable(long boardIdx){
-        uncomfortableRepository.deleteById(boardIdx);
+    public void deleteThisUncomfortable(long uncomfortableIdx){
+        uncomfortableRepository.deleteById(uncomfortableIdx);
     }
 
     /**

--- a/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
+++ b/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
@@ -34,7 +34,7 @@ public class UncomfortableService {
     /**
      * 많은 학생들이 공감한 글 상위 30개를 선별하여 가져옵니다.
      * @return List&#60;UncomfortableGetDto&#62;
-     * @author 정시원, 전지환
+     * @author 정시원
      */
     public List<UncomfortableResponseDto> getRank() {
         return uncomfortableRepository.uncomfortableViewTopBy(30);
@@ -43,7 +43,7 @@ public class UncomfortableService {
     /**
      * 학교의 불편함 전체를 가져옵니다.
      * @return List&#60;UncomfortableGetDto&#62;
-     * @author 정시원, 전지환
+     * @author 정시원
      */
     public List<UncomfortableResponseDto> getAllUncomfortable(){
         return uncomfortableRepository.uncomfortableViewAll();
@@ -51,21 +51,21 @@ public class UncomfortableService {
 
     /**
      * 해당 불편함의 좋아요를 증가시킵니다.
-     * @param boardIdx
+     * @param uncomfortableIdx
      */
     @Transactional
-    public void increaseLike(Long boardIdx){
-        UncomfortableDomain uncomfortableDomain = uncomfortableRepository.findByUncomfortableIdx(boardIdx).orElseThrow(NoPostException::new);
+    public void increaseLike(Long uncomfortableIdx){
+        UncomfortableDomain uncomfortableDomain = uncomfortableRepository.findByUncomfortableIdx(uncomfortableIdx).orElseThrow(NoPostException::new);
         uncomfortableDomain.updateGoods(uncomfortableDomain.getGoods()+1);
     }
 
     /**
      * 해당 불편함의 좋아요를 감소시킵니다.
-     * @param boardIdx
+     * @param uncomfortableIdx
      */
     @Transactional
-    public void decreaseLike(Long boardIdx) {
-        UncomfortableDomain uncomfortableDomain = uncomfortableRepository.findByUncomfortableIdx(boardIdx).orElseThrow(NoPostException::new);
+    public void decreaseLike(Long uncomfortableIdx) {
+        UncomfortableDomain uncomfortableDomain = uncomfortableRepository.findByUncomfortableIdx(uncomfortableIdx).orElseThrow(NoPostException::new);
         int goodsResult = uncomfortableDomain.getGoods() - 1;
 
         if(goodsResult > -1) {//좋야요가 양수일때

--- a/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
+++ b/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
@@ -8,7 +8,6 @@ import com.moment.the.uncomfortable.dto.UncomfortableSetDto;
 import com.moment.the.uncomfortable.repository.UncomfortableRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,14 +34,16 @@ public class UncomfortableService {
     /**
      * 많은 학생들이 공감한 글 상위 30개를 선별하여 가져옵니다.
      * @return List<UncomfortableGetDto>
+     * @author 정시원, 전지환
      */
     public List<UncomfortableResponseDto> getRank() {
-        return uncomfortableRepository.uncomfortableViewTopBy(PageRequest.of(0,30));
+        return uncomfortableRepository.uncomfortableViewTopBy(30);
     }
 
     /**
      * 학교의 불편함 전체를 가져옵니다.
      * @return List<UncomfortableGetDto>
+     * @author 정시원, 전지환
      */
     public List<UncomfortableResponseDto> getAllUncomfortable(){
         return uncomfortableRepository.uncomfortableViewAll();

--- a/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
+++ b/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
@@ -85,11 +85,10 @@ public class UncomfortableService {
 
     /**
      * 불편함의 개수를 세어 가져옵니다.
-     * @return UncomfortableDomain의 전체 조회 개수
-     * @author 정시원, 전지환
+     * @return Long
      */
     public Long getNumberOfUncomfortable(){
-        return uncomfortableRepository.count();
+        return uncomfortableRepository.amountUncomfortable();
     }
 
     /**

--- a/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
+++ b/src/main/java/com/moment/the/uncomfortable/service/UncomfortableService.java
@@ -85,10 +85,11 @@ public class UncomfortableService {
 
     /**
      * 불편함의 개수를 세어 가져옵니다.
-     * @return Long
+     * @return UncomfortableDomain의 전체 조회 개수
+     * @author 정시원, 전지환
      */
     public Long getNumberOfUncomfortable(){
-        return uncomfortableRepository.amountUncomfortable();
+        return uncomfortableRepository.count();
     }
 
     /**


### PR DESCRIPTION
### 한 일
#### 1. `UncomfortableRepository`를 CustomRepository 기능을 이용해 Jpql를 사용하는 매서드를 querydsl로 이전했습니다.
#205 에서 수정한 `amountUncomfortable`를 제외한 모든 메서드를 querydsl로 이전했습니다.
이 과정에서 `UncomfortableService`의 `getRank()` 로직이랑 `UncomfortableResponseDto` 속 필드와 생성자 그리고 annotation의 구성이 달라지고 이로 인해 API가 변경되었습니다. 
> API 변경사항과 `UncomfortableResponseDto`변경사항은 밑에 기술하겠습니다.

#### 2. `UncomfortableService`에서 `deleteThisUncomfortable`매서드에 파라미터의 변수명을 `uncomfortableIdx`로 변경했습니다.
`boardIdx`라고 보이길래 참을 수 없어서 변수명 변경 했습니다.

#### 3. UncomfortableService 주석에서 부등호문자(`<` , `>`)를 HTML특수문자로 치환했습니다.
Java Doc주석은 html기반으로 되어있어 부등호가 html태그로 인식되어 사용하지 않는 게 좋다고 생각해서 변경했습니다.

부등호문자(`<`, `>`)를 사용했을 때 java doc
![image](https://user-images.githubusercontent.com/62932968/134773358-45cbfdf4-b4e9-4474-84f9-05a0e1302875.png)

HTML특수문자를 사용했을 때 java doc
![image](https://user-images.githubusercontent.com/62932968/134773330-56d34233-461f-4d71-826c-4346fb229d7d.png)

### API + DTO 변경사항
- `UncomfortableResponseDto`에서 `boardIdx`필드명을 `uncomfortableIdx`로 변경하면서 ResponseBody가 변경되었습니다.

- 불편한순간 모두 가져오기API(`/v1/uncomfortable`)는 isAnswer이 필요하지 않으므로 반환하지 않습니다.

API변경사항은 [notion](https://www.notion.so/the-moment/API-v-1-1-1-v-1-1-2-4645abee4afe4bbdb7e7083c1b52341a)에 작성했습니다.
### 코드리뷰 원해요
- 전반적인 변수명, 매서드명, 클래스명에 대한 피드백
- 주석에 대한 피드백
- API변경사항에 대한 피드백

### 추가적인 제안사항
`UncomfortableDomain`의 예전 idx명인 `boardIdx`가 controller의 쿼리파라미터에 그대로 남아 있습니다. `UncomfortableDomain`의 현제 idx인 `uncomfortableIdx`로 이름을 변경 해야 할 거 같아요
![image](https://user-images.githubusercontent.com/62932968/134778397-ca442854-8040-4b59-abdc-6cd83c374f0d.png)

![image](https://user-images.githubusercontent.com/62932968/134778437-72cf8d5a-54cb-4dd0-a768-57290395888c.png)
