### PR TITLE
[hotfix] could not connect redis exception

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       - "5000:8080"
     links:
       - "db:redis"
-  db:
-    image: "redis"
-    hostname: redis
-    ports:
-      - "6379:6379"
+  redis:
+    image: redis:latest
+    command: ["redis-server", "--bind", "redis", "--port", "6379"]


### PR DESCRIPTION
### What's wrong?
회원가입 후 로그인 시도하는데 .. `unable to connect redis exception` 이 발생했습니다.
```json
{
    "success": false,
    "code": -9999,
    "msg": "Unable to connect to Redis; nested exception is io.lettuce.core.RedisConnectionException: Unable to connect to localhost:6379"
}
```

### How I Fixed it ?
[이 방법을 사용하여](https://github.com/luin/ioredis/issues/763) 운영에서 정상적으로 작동하는지 실험해보려 합니다.

### Before & After
Before
```yml
db:
    image: "redis"
    hostname: redis
    ports:
      - "6379:6379"
```

After
```yml
redis:
    image: redis:latest
    command: ["redis-server", "--bind", "redis", "--port", "6379"]
```