### PR TITLE
Fix http status가 항상 200를 logging하는 문제 해결

### DIFF
--- a/src/main/java/com/moment/the/config/mvc/RequestResponseLoggingFilter.java
+++ b/src/main/java/com/moment/the/config/mvc/RequestResponseLoggingFilter.java
@@ -22,13 +22,14 @@ import java.util.Map;
 public class RequestResponseLoggingFilter extends OncePerRequestFilter {
 
     @Override
-    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws ServletException, IOException {
-        ContentCachingResponseWrapper resWrapper = new ContentCachingResponseWrapper(res);
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+        ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
 
+        chain.doFilter(requestWrapper, responseWrapper);
         log.info("[REQUEST] {} - {} {}",
-                req.getMethod(), req.getRequestURI(), resWrapper.getStatus()
+                requestWrapper.getMethod(), requestWrapper.getRequestURI(), responseWrapper.getStatus()
         );
-        chain.doFilter(req, res);
     }
 
 }

--- a/src/main/java/com/moment/the/config/mvc/RequestResponseLoggingFilter.java
+++ b/src/main/java/com/moment/the/config/mvc/RequestResponseLoggingFilter.java
@@ -27,7 +27,7 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
         ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
 
         chain.doFilter(requestWrapper, responseWrapper);
-        log.info("[REQUEST] {} - {} {}",
+        log.info("[REQUEST/RESPONSE] {} - {} {}",
                 requestWrapper.getMethod(), requestWrapper.getRequestURI(), responseWrapper.getStatus()
         );
     }


### PR DESCRIPTION
### 한 일
request/response에 대해 항상 console에  http status 200을 logging 하는 문제를 해결했습니다.

원인은 모든 요청이 완료된 후 http status코드를 반환해야되지만 요청된 작업이 실행되기도 전에 logging을 하게 되어서 항상 http status code 200를 반환했습니다. 

해결방법은 `doFIlter`매서드 뒤에 wrapping된 `response`객체의 status코드를 가져와 해결했습니다.

해결 예시
![image](https://user-images.githubusercontent.com/62932968/134838213-4e86b188-9c91-4e92-b510-fa96bb8c108f.png)
